### PR TITLE
Enable toxcore logging when building on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ script:
         --with-libsodium-libs=$CACHE_DIR/lib \
         --with-libsodium-headers=$CACHE_DIR/include \
         --enable-daemon \
+        --enable-logging \
         --enable-ntox \
         CFLAGS="-O0 -Wall -Wextra -fprofile-arcs -ftest-coverage"
   - make


### PR DESCRIPTION
The logging code is rarely tested by users, so we use Travis to exercise it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/2)
<!-- Reviewable:end -->
