### PR TITLE
 Replace *Tox as a pointer to *Messenger to it's own struct

### DIFF
--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -204,7 +204,7 @@ typedef struct {
     void *object;
 } Cryptopacket_Handles;
 
-typedef struct {
+typedef struct DHT {
     Networking_Core *net;
 
     Client_data    close_clientlist[LCLIENT_LIST];

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -20,7 +20,7 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
                         ../toxcore/friend_requests.c \
                         ../toxcore/LAN_discovery.h \
                         ../toxcore/LAN_discovery.c \
-                        ../toxcore/friend_connection.h \
+                        ../toxcore/tox_connection.h \
                         ../toxcore/tox_connection.c \
                         ../toxcore/Messenger.h \
                         ../toxcore/Messenger.c \

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -21,7 +21,7 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
                         ../toxcore/LAN_discovery.h \
                         ../toxcore/LAN_discovery.c \
                         ../toxcore/friend_connection.h \
-                        ../toxcore/friend_connection.c \
+                        ../toxcore/tox_connection.c \
                         ../toxcore/Messenger.h \
                         ../toxcore/Messenger.c \
                         ../toxcore/ping.h \

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -150,14 +150,14 @@ static int send_online_packet(Messenger *m, int32_t friendnumber)
         return 0;
 
     uint8_t packet = PACKET_ID_ONLINE;
-    return write_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                              m->friendlist[friendnumber].friendcon_id), &packet, sizeof(packet), 0) != -1;
 }
 
 static int send_offline_packet(Messenger *m, int friendcon_id)
 {
     uint8_t packet = PACKET_ID_OFFLINE;
-    return write_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c, friendcon_id), &packet,
+    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c, friendcon_id), &packet,
                              sizeof(packet), 0) != -1;
 }
 
@@ -173,7 +173,7 @@ static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t sta
 
     memset(&(m->friendlist[m->numfriends]), 0, sizeof(Friend));
 
-    int friendcon_id = new_friend_connection(m->fr_c, real_pk);
+    int friendcon_id = new_tox_conn(m->fr_c, real_pk);
 
     if (friendcon_id == -1)
         return FAERR_NOMEM;
@@ -190,13 +190,13 @@ static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t sta
             m->friendlist[i].userstatus = USERSTATUS_NONE;
             m->friendlist[i].is_typing = 0;
             m->friendlist[i].message_id = 0;
-            friend_connection_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
+            tox_conn_set_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
                                         &handle_custom_lossy_packet, m, i);
 
             if (m->numfriends == i)
                 ++m->numfriends;
 
-            if (friend_con_connected(m->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
+            if (tox_conn_is_connected(m->fr_c, friendcon_id) == TOXCONN_STATUS_CONNECTED) {
                 send_online_packet(m, i);
             }
 
@@ -340,7 +340,7 @@ static int friend_received_packet(const Messenger *m, int32_t friendnumber, uint
     if (friend_not_valid(m, friendnumber))
         return -1;
 
-    return cryptpacket_received(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    return cryptpacket_received(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                                 m->friendlist[friendnumber].friendcon_id), number);
 }
 
@@ -386,13 +386,13 @@ int m_delfriend(Messenger *m, int32_t friendnumber)
 
     clear_receipts(m, friendnumber);
     remove_request_received(&(m->fr), m->friendlist[friendnumber].real_pk);
-    friend_connection_callbacks(m->fr_c, m->friendlist[friendnumber].friendcon_id, MESSENGER_CALLBACK_INDEX, 0, 0, 0, 0, 0);
+    tox_conn_set_callbacks(m->fr_c, m->friendlist[friendnumber].friendcon_id, MESSENGER_CALLBACK_INDEX, 0, 0, 0, 0, 0);
 
-    if (friend_con_connected(m->fr_c, m->friendlist[friendnumber].friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
+    if (tox_conn_is_connected(m->fr_c, m->friendlist[friendnumber].friendcon_id) == TOXCONN_STATUS_CONNECTED) {
         send_offline_packet(m, m->friendlist[friendnumber].friendcon_id);
     }
 
-    kill_friend_connection(m->fr_c, m->friendlist[friendnumber].friendcon_id);
+    kill_tox_conn(m->fr_c, m->friendlist[friendnumber].friendcon_id);
     memset(&(m->friendlist[friendnumber]), 0, sizeof(Friend));
     uint32_t i;
 
@@ -417,7 +417,7 @@ int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber)
     if (m->friendlist[friendnumber].status == FRIEND_ONLINE) {
         _Bool direct_connected = 0;
         unsigned int num_online_relays = 0;
-        crypto_connection_status(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+        crypto_connection_status(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                                  m->friendlist[friendnumber].friendcon_id), &direct_connected, &num_online_relays);
 
         if (direct_connected) {
@@ -472,7 +472,7 @@ int m_send_message_generic(Messenger *m, int32_t friendnumber, uint8_t type, con
     if (length != 0)
         memcpy(packet + 1, message, length);
 
-    int64_t packet_num = write_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    int64_t packet_num = write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                                            m->friendlist[friendnumber].friendcon_id), packet, length + 1, 0);
 
     if (packet_num == -1)
@@ -905,7 +905,7 @@ static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_
     if (length != 0)
         memcpy(packet + 1, data, length);
 
-    return write_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                              m->friendlist[friendnumber].friendcon_id), packet, length + 1, congestion_control) != -1;
 }
 
@@ -1298,7 +1298,7 @@ static int64_t send_file_data_packet(const Messenger *m, int32_t friendnumber, u
         memcpy(packet + 2, data, length);
     }
 
-    return write_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                              m->friendlist[friendnumber].friendcon_id), packet, sizeof(packet), 1);
 }
 
@@ -1348,7 +1348,7 @@ int file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
     }
 
     /* Prevent file sending from filling up the entire buffer preventing messages from being sent. TODO: remove */
-    if (crypto_num_free_sendqueue_slots(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    if (crypto_num_free_sendqueue_slots(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                                         m->friendlist[friendnumber].friendcon_id)) < MIN_SLOTS_FREE)
         return -6;
 
@@ -1406,7 +1406,7 @@ static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
     if (!m->friendlist[friendnumber].num_sending_files)
         return;
 
-    int free_slots = crypto_num_free_sendqueue_slots(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    int free_slots = crypto_num_free_sendqueue_slots(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                      m->friendlist[friendnumber].friendcon_id));
 
     if (free_slots < MIN_SLOTS_FREE) {
@@ -1443,7 +1443,7 @@ static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
         }
 
         while (ft->status == FILESTATUS_TRANSFERRING && (ft->paused == FILE_PAUSE_NOT)) {
-            if (max_speed_reached(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+            if (max_speed_reached(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                                   m->friendlist[friendnumber].friendcon_id))) {
                 free_slots = 0;
             }
@@ -1677,7 +1677,7 @@ int send_custom_lossy_packet(const Messenger *m, int32_t friendnumber, const uin
     if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -4;
 
-    if (send_lossy_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    if (send_lossy_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                                m->friendlist[friendnumber].friendcon_id), data, length) == -1) {
         return -5;
     } else {
@@ -1728,7 +1728,7 @@ int send_custom_lossless_packet(const Messenger *m, int32_t friendnumber, const 
     if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -4;
 
-    if (write_cryptpacket(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
+    if (write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
                           m->friendlist[friendnumber].friendcon_id), data, length, 1) == -1) {
         return -5;
     } else {
@@ -1799,10 +1799,10 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
     m->onion = new_onion(m->dht);
     m->onion_a = new_onion_announce(m->dht);
     m->onion_c =  new_onion_client(m->net_crypto);
-    m->fr_c = new_friend_connections(m->onion_c);
+    m->fr_c = new_tox_conns(m->onion_c);
 
     if (!(m->onion && m->onion_a && m->onion_c)) {
-        kill_friend_connections(m->fr_c);
+        kill_tox_conns(m->fr_c);
         kill_onion(m->onion);
         kill_onion_announce(m->onion_a);
         kill_onion_client(m->onion_c);
@@ -1817,7 +1817,7 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
         m->tcp_server = new_TCP_server(options->ipv6enabled, 1, &options->tcp_server_port, m->dht->self_secret_key, m->onion);
 
         if (m->tcp_server == NULL) {
-            kill_friend_connections(m->fr_c);
+            kill_tox_conns(m->fr_c);
             kill_onion(m->onion);
             kill_onion_announce(m->onion_a);
             kill_onion_client(m->onion_c);
@@ -1856,7 +1856,7 @@ void kill_messenger(Messenger *m)
         kill_TCP_server(m->tcp_server);
     }
 
-    kill_friend_connections(m->fr_c);
+    kill_tox_conns(m->fr_c);
     kill_onion(m->onion);
     kill_onion_announce(m->onion_a);
     kill_onion_client(m->onion_c);
@@ -2182,7 +2182,7 @@ void do_friends(Messenger *m)
 
     for (i = 0; i < m->numfriends; ++i) {
         if (m->friendlist[i].status == FRIEND_ADDED) {
-            int fr = send_friend_request_packet(m->fr_c, m->friendlist[i].friendcon_id, m->friendlist[i].friendrequest_nospam,
+            int fr = send_tox_conn_request_pkt(m->fr_c, m->friendlist[i].friendcon_id, m->friendlist[i].friendrequest_nospam,
                                                 m->friendlist[i].info,
                                                 m->friendlist[i].info_size);
 
@@ -2317,7 +2317,7 @@ void do_messenger(Messenger *m)
 
     do_net_crypto(m->net_crypto);
     do_onion_client(m->onion_c);
-    do_friend_connections(m->fr_c);
+    do_tox_connections(m->fr_c);
     do_friends(m);
     connection_status_cb(m);
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -35,10 +35,9 @@
 #include "network.h"
 #include "util.h"
 
-
-static void set_friend_status(Messenger *m, int32_t friendnumber, uint8_t status);
-static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_t packet_id, const uint8_t *data,
-                                uint32_t length, uint8_t congestion_control);
+static void set_friend_status(Tox *tox, int32_t friendnumber, uint8_t status);
+static int write_cryptpacket_id(const Tox *tox, int32_t friendnumber, uint8_t packet_id,
+                                const uint8_t *data, uint32_t length, uint8_t congestion_control);
 
 // friend_not_valid determines if the friendnumber passed is valid in the Messenger object
 static uint8_t friend_not_valid(const Messenger *m, int32_t friendnumber)
@@ -95,24 +94,27 @@ int32_t getfriend_id(const Messenger *m, const uint8_t *real_pk)
  *  return 0 if success.
  *  return -1 if failure.
  */
-int get_real_pk(const Messenger *m, int32_t friendnumber, uint8_t *real_pk)
+int get_real_pk(const Tox *tox, int32_t friendnumber, uint8_t *real_pk)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber)) {
         return -1;
+    }
 
-    memcpy(real_pk, m->friendlist[friendnumber].real_pk, crypto_box_PUBLICKEYBYTES);
+    /* TODO: we should return an array here? Or maybe replace/entend this fxn */
+    memcpy(real_pk, tox->m->friendlist[friendnumber].real_pk, crypto_box_PUBLICKEYBYTES);
     return 0;
 }
 
 /*  return friend connection id on success.
  *  return -1 if failure.
  */
-int getfriendcon_id(const Messenger *m, int32_t friendnumber)
+int getfriendcon_id(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    return m->friendlist[friendnumber].friendcon_id;
+    /* TODO: we should return an array here? Or maybe replace/entend this fxn */
+    return tox->m->friendlist[friendnumber].friendcon_id;
 }
 
 /*
@@ -135,45 +137,56 @@ static uint16_t address_checksum(const uint8_t *address, uint32_t len)
  *
  *  return FRIEND_ADDRESS_SIZE byte address to give to others.
  */
-void getaddress(const Messenger *m, uint8_t *address)
+void getaddress(const Tox *tox, uint8_t *address)
 {
-    id_copy(address, m->net_crypto->self_public_key);
-    uint32_t nospam = get_nospam(&(m->fr));
+    id_copy(address, tox->net_crypto->self_public_key);
+    uint32_t nospam = get_nospam(&tox->m->fr);
     memcpy(address + crypto_box_PUBLICKEYBYTES, &nospam, sizeof(nospam));
     uint16_t checksum = address_checksum(address, FRIEND_ADDRESS_SIZE - sizeof(checksum));
     memcpy(address + crypto_box_PUBLICKEYBYTES + sizeof(nospam), &checksum, sizeof(checksum));
 }
 
-static int send_online_packet(Messenger *m, int32_t friendnumber)
+static int send_online_packet(Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber)) {
         return 0;
+    }
 
     uint8_t packet = PACKET_ID_ONLINE;
-    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                             m->friendlist[friendnumber].friendcon_id), &packet, sizeof(packet), 0) != -1;
+    return write_cryptpacket(tox->net_crypto,
+                             toxconn_crypt_connection_id(tox->tox_conn,
+                                                         tox->m->friendlist[friendnumber].friendcon_id),
+                             &packet,
+                             sizeof(packet),
+                             0) != -1;
 }
 
-static int send_offline_packet(Messenger *m, int friendcon_id)
+static int send_offline_packet(Tox *tox, int friendcon_id)
 {
     uint8_t packet = PACKET_ID_OFFLINE;
-    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c, friendcon_id), &packet,
+    return write_cryptpacket(tox->net_crypto,
+                             toxconn_crypt_connection_id(tox->tox_conn,
+                                                         friendcon_id),
+                             &packet,
                              sizeof(packet), 0) != -1;
 }
 
-static int handle_status(void *object, int i, uint8_t status);
-static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len);
+static int handle_status(void *object, int friend_num, uint8_t status);
+static int handle_packet(void *object, int friend_num, uint8_t *temp, uint16_t len);
 static int handle_custom_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length);
 
-static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t status)
+static int32_t init_new_friend(Tox *tox, const uint8_t *real_pk, uint8_t status)
 {
+    Messenger *m = tox->m;
+
     /* Resize the friend list if necessary. */
     if (realloc_friendlist(m, m->numfriends + 1) != 0)
         return FAERR_NOMEM;
 
     memset(&(m->friendlist[m->numfriends]), 0, sizeof(Friend));
 
-    int friendcon_id = new_tox_conn(m->fr_c, real_pk);
+
+    int friendcon_id = new_tox_conn(tox->tox_conn, real_pk);
 
     if (friendcon_id == -1)
         return FAERR_NOMEM;
@@ -190,14 +203,17 @@ static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t sta
             m->friendlist[i].userstatus = USERSTATUS_NONE;
             m->friendlist[i].is_typing = 0;
             m->friendlist[i].message_id = 0;
-            tox_conn_set_callbacks(m->fr_c, friendcon_id, MESSENGER_CALLBACK_INDEX, &handle_status, &handle_packet,
-                                        &handle_custom_lossy_packet, m, i);
+            toxconn_set_callbacks(tox->tox_conn, friendcon_id, MESSENGER_CALLBACK_INDEX,
+                                  &handle_status, &handle_packet, &handle_custom_lossy_packet,
+                                  tox, i);
 
-            if (m->numfriends == i)
+            if (m->numfriends == i) {
                 ++m->numfriends;
+            }
 
-            if (tox_conn_is_connected(m->fr_c, friendcon_id) == TOXCONN_STATUS_CONNECTED) {
-                send_online_packet(m, i);
+            if (toxconn_is_connected(tox->tox_conn, friendcon_id) == TOXCONN_STATUS_CONNECTED) {
+                m->friendlist[i].status = FRIEND_ONLINE;
+                send_online_packet(tox, i);
             }
 
             return i;
@@ -223,7 +239,7 @@ static int32_t init_new_friend(Messenger *m, const uint8_t *real_pk, uint8_t sta
  *  (the nospam for that friend was set to the new one).
  *  return FAERR_NOMEM if increasing the friend list size fails.
  */
-int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, uint16_t length)
+int32_t m_addfriend(Tox *tox, const uint8_t *address, const uint8_t *data, uint16_t length)
 {
     if (length > MAX_FRIEND_REQUEST_DATA_SIZE)
         return FAERR_TOOLONG;
@@ -243,51 +259,51 @@ int32_t m_addfriend(Messenger *m, const uint8_t *address, const uint8_t *data, u
     if (length < 1)
         return FAERR_NOMESSAGE;
 
-    if (id_equal(real_pk, m->net_crypto->self_public_key))
+    if (id_equal(real_pk, tox->net_crypto->self_public_key))
         return FAERR_OWNKEY;
 
-    int32_t friend_id = getfriend_id(m, real_pk);
+    int32_t friend_id = getfriend_id(tox->m, real_pk);
 
     if (friend_id != -1) {
-        if (m->friendlist[friend_id].status >= FRIEND_CONFIRMED)
+        if (tox->m->friendlist[friend_id].status >= FRIEND_CONFIRMED)
             return FAERR_ALREADYSENT;
 
         uint32_t nospam;
         memcpy(&nospam, address + crypto_box_PUBLICKEYBYTES, sizeof(nospam));
 
-        if (m->friendlist[friend_id].friendrequest_nospam == nospam)
+        if (tox->m->friendlist[friend_id].friendrequest_nospam == nospam)
             return FAERR_ALREADYSENT;
 
-        m->friendlist[friend_id].friendrequest_nospam = nospam;
+        tox->m->friendlist[friend_id].friendrequest_nospam = nospam;
         return FAERR_SETNEWNOSPAM;
     }
 
-    int32_t ret = init_new_friend(m, real_pk, FRIEND_ADDED);
+    int32_t ret = init_new_friend(tox, real_pk, FRIEND_ADDED);
 
     if (ret < 0) {
         return ret;
     }
 
-    m->friendlist[ret].friendrequest_timeout = FRIENDREQUEST_TIMEOUT;
-    memcpy(m->friendlist[ret].info, data, length);
-    m->friendlist[ret].info_size = length;
-    memcpy(&(m->friendlist[ret].friendrequest_nospam), address + crypto_box_PUBLICKEYBYTES, sizeof(uint32_t));
+    tox->m->friendlist[ret].friendrequest_timeout = FRIENDREQUEST_TIMEOUT;
+    memcpy(tox->m->friendlist[ret].info, data, length);
+    tox->m->friendlist[ret].info_size = length;
+    memcpy(&(tox->m->friendlist[ret].friendrequest_nospam), address + crypto_box_PUBLICKEYBYTES, sizeof(uint32_t));
 
     return ret;
 }
 
-int32_t m_addfriend_norequest(Messenger *m, const uint8_t *real_pk)
+int32_t m_addfriend_norequest(Tox *tox, const uint8_t *real_pk)
 {
-    if (getfriend_id(m, real_pk) != -1)
+    if (getfriend_id(tox->m, real_pk) != -1)
         return FAERR_ALREADYSENT;
 
     if (!public_key_valid(real_pk))
         return FAERR_BADCHECKSUM;
 
-    if (id_equal(real_pk, m->net_crypto->self_public_key))
+    if (id_equal(real_pk, tox->net_crypto->self_public_key))
         return FAERR_OWNKEY;
 
-    return init_new_friend(m, real_pk, FRIEND_CONFIRMED);
+    return init_new_friend(tox, real_pk, FRIEND_CONFIRMED);
 }
 
 static int clear_receipts(Messenger *m, int32_t friendnumber)
@@ -308,9 +324,9 @@ static int clear_receipts(Messenger *m, int32_t friendnumber)
     return 0;
 }
 
-static int add_receipt(Messenger *m, int32_t friendnumber, uint32_t packet_num, uint32_t msg_id)
+static int add_receipt(Tox *tox, int32_t friendnumber, uint32_t packet_num, uint32_t msg_id)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
     struct Receipts *new = calloc(1, sizeof(struct Receipts));
@@ -321,52 +337,57 @@ static int add_receipt(Messenger *m, int32_t friendnumber, uint32_t packet_num, 
     new->packet_num = packet_num;
     new->msg_id = msg_id;
 
-    if (!m->friendlist[friendnumber].receipts_start) {
-        m->friendlist[friendnumber].receipts_start = new;
+    if (!tox->m->friendlist[friendnumber].receipts_start) {
+        tox->m->friendlist[friendnumber].receipts_start = new;
     } else {
-        m->friendlist[friendnumber].receipts_end->next = new;
+        tox->m->friendlist[friendnumber].receipts_end->next = new;
     }
 
-    m->friendlist[friendnumber].receipts_end = new;
+    tox->m->friendlist[friendnumber].receipts_end = new;
     new->next = NULL;
     return 0;
 }
+
 /*
  * return -1 on failure.
  * return 0 if packet was received.
  */
-static int friend_received_packet(const Messenger *m, int32_t friendnumber, uint32_t number)
+static int friend_received_packet(const Tox *tox, int32_t friendnumber, uint32_t number)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    return cryptpacket_received(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                                m->friendlist[friendnumber].friendcon_id), number);
+    return cryptpacket_received(tox->net_crypto,
+                                toxconn_crypt_connection_id(tox->tox_conn,
+                                                            tox->m->friendlist[friendnumber].friendcon_id),
+                                number);
 }
 
-static int do_receipts(Messenger *m, int32_t friendnumber)
+static int do_receipts(Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    Messenger *m = tox->m;
+
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    struct Receipts *receipts = m->friendlist[friendnumber].receipts_start;
+    struct Receipts *receipts = tox->m->friendlist[friendnumber].receipts_start;
 
     while (receipts) {
         struct Receipts *temp_r = receipts->next;
 
-        if (friend_received_packet(m, friendnumber, receipts->packet_num) == -1)
+        if (friend_received_packet(tox, friendnumber, receipts->packet_num) == -1)
             break;
 
-        if (m->read_receipt)
-            (*m->read_receipt)(m, friendnumber, receipts->msg_id, m->read_receipt_userdata);
+        if (tox->m->read_receipt)
+            (*tox->m->read_receipt)(tox, friendnumber, receipts->msg_id, tox->m->read_receipt_userdata);
 
         free(receipts);
-        m->friendlist[friendnumber].receipts_start = temp_r;
+        tox->m->friendlist[friendnumber].receipts_start = temp_r;
         receipts = temp_r;
     }
 
-    if (!m->friendlist[friendnumber].receipts_start)
-        m->friendlist[friendnumber].receipts_end = NULL;
+    if (!tox->m->friendlist[friendnumber].receipts_start)
+        tox->m->friendlist[friendnumber].receipts_end = NULL;
 
     return 0;
 }
@@ -376,49 +397,56 @@ static int do_receipts(Messenger *m, int32_t friendnumber)
  *  return 0 if success.
  *  return -1 if failure.
  */
-int m_delfriend(Messenger *m, int32_t friendnumber)
+int m_delfriend(Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    Messenger *m = tox->m;
+
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    if (m->friend_connectionstatuschange_internal)
-        m->friend_connectionstatuschange_internal(m, friendnumber, 0, m->friend_connectionstatuschange_internal_userdata);
+    if (tox->m->friend_connectionstatuschange_internal)
+        tox->m->friend_connectionstatuschange_internal(tox, friendnumber, 0, tox->m->friend_connectionstatuschange_internal_userdata);
 
-    clear_receipts(m, friendnumber);
-    remove_request_received(&(m->fr), m->friendlist[friendnumber].real_pk);
-    tox_conn_set_callbacks(m->fr_c, m->friendlist[friendnumber].friendcon_id, MESSENGER_CALLBACK_INDEX, 0, 0, 0, 0, 0);
+    clear_receipts(tox->m, friendnumber);
+    remove_request_received(&(tox->m->fr), tox->m->friendlist[friendnumber].real_pk);
+    toxconn_set_callbacks(tox->tox_conn, tox->m->friendlist[friendnumber].friendcon_id, MESSENGER_CALLBACK_INDEX, 0, 0, 0, 0, 0);
 
-    if (tox_conn_is_connected(m->fr_c, m->friendlist[friendnumber].friendcon_id) == TOXCONN_STATUS_CONNECTED) {
-        send_offline_packet(m, m->friendlist[friendnumber].friendcon_id);
+    if (toxconn_is_connected(tox->tox_conn, tox->m->friendlist[friendnumber].friendcon_id) == TOXCONN_STATUS_CONNECTED) {
+        send_offline_packet(tox, tox->m->friendlist[friendnumber].friendcon_id);
     }
 
-    kill_tox_conn(m->fr_c, m->friendlist[friendnumber].friendcon_id);
-    memset(&(m->friendlist[friendnumber]), 0, sizeof(Friend));
+    kill_tox_conn(tox->tox_conn, tox->m->friendlist[friendnumber].friendcon_id);
+    memset(&(tox->m->friendlist[friendnumber]), 0, sizeof(Friend));
     uint32_t i;
 
-    for (i = m->numfriends; i != 0; --i) {
-        if (m->friendlist[i - 1].status != NOFRIEND)
+    for (i = tox->m->numfriends; i != 0; --i) {
+        if (tox->m->friendlist[i - 1].status != NOFRIEND)
             break;
     }
 
-    m->numfriends = i;
+    tox->m->numfriends = i;
 
-    if (realloc_friendlist(m, m->numfriends) != 0)
+    if (realloc_friendlist(m, tox->m->numfriends) != 0)
         return FAERR_NOMEM;
 
     return 0;
 }
 
-int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber)
+int m_get_friend_connectionstatus(const Tox *tox, int32_t fr_id)
 {
-    if (friend_not_valid(m, friendnumber))
+    Messenger *m = tox->m;
+
+    if (friend_not_valid(m, fr_id))
         return -1;
 
-    if (m->friendlist[friendnumber].status == FRIEND_ONLINE) {
+    if (m->friendlist[fr_id].status == FRIEND_ONLINE) {
         _Bool direct_connected = 0;
         unsigned int num_online_relays = 0;
-        crypto_connection_status(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                                 m->friendlist[friendnumber].friendcon_id), &direct_connected, &num_online_relays);
+        crypto_connection_status(tox->net_crypto,
+                                 toxconn_crypt_connection_id(tox->tox_conn,
+                                                             m->friendlist[fr_id].friendcon_id),
+                                 &direct_connected,
+                                 &num_online_relays);
 
         if (direct_connected) {
             return CONNECTION_UDP;
@@ -434,9 +462,9 @@ int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber)
     }
 }
 
-int m_friend_exists(const Messenger *m, int32_t friendnumber)
+int m_friend_exists(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return 0;
 
     return 1;
@@ -451,9 +479,11 @@ int m_friend_exists(const Messenger *m, int32_t friendnumber)
  * return -5 if bad type.
  * return 0 if success.
  */
-int m_send_message_generic(Messenger *m, int32_t friendnumber, uint8_t type, const uint8_t *message, uint32_t length,
+int m_send_message_generic(Tox *tox, int32_t friendnumber, uint8_t type, const uint8_t *message, uint32_t length,
                            uint32_t *message_id)
 {
+    Messenger *m = tox->m;
+
     if (type > MESSAGE_ACTION)
         return -5;
 
@@ -472,15 +502,18 @@ int m_send_message_generic(Messenger *m, int32_t friendnumber, uint8_t type, con
     if (length != 0)
         memcpy(packet + 1, message, length);
 
-    int64_t packet_num = write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                                           m->friendlist[friendnumber].friendcon_id), packet, length + 1, 0);
+    uint32_t dev = UINT32_MAX;
+    int64_t packet_num = -1;
+
+    int crypt_con_id = toxconn_crypt_connection_id(tox->tox_conn, m->friendlist[friendnumber].friendcon_id);
+    int64_t this_packet_num = write_cryptpacket(tox->net_crypto, crypt_con_id, packet, length + 1, 0);
 
     if (packet_num == -1)
         return -4;
 
     uint32_t msg_id = ++m->friendlist[friendnumber].message_id;
 
-    add_receipt(m, friendnumber, packet_num, msg_id);
+    add_receipt(tox, friendnumber, packet_num, msg_id);
 
     if (message_id)
         *message_id = msg_id;
@@ -491,12 +524,12 @@ int m_send_message_generic(Messenger *m, int32_t friendnumber, uint8_t type, con
 /* Send a name packet to friendnumber.
  * length is the length with the NULL terminator.
  */
-static int m_sendname(const Messenger *m, int32_t friendnumber, const uint8_t *name, uint16_t length)
+static int m_sendname(const Tox *tox, int32_t friendnumber, const uint8_t *name, uint16_t length)
 {
     if (length > MAX_NAME_LENGTH)
         return 0;
 
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_NICKNAME, name, length, 0);
+    return write_cryptpacket_id(tox, friendnumber, PACKET_ID_NICKNAME, name, length, 0);
 }
 
 /* Set the name and name_length of a friend.
@@ -576,79 +609,81 @@ int getname(const Messenger *m, int32_t friendnumber, uint8_t *name)
     return m->friendlist[friendnumber].name_length;
 }
 
-int m_get_name_size(const Messenger *m, int32_t friendnumber)
+int m_get_name_size(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    return m->friendlist[friendnumber].name_length;
+    return tox->m->friendlist[friendnumber].name_length;
 }
 
-int m_get_self_name_size(const Messenger *m)
+int m_get_self_name_size(const Tox *tox)
 {
-    return m->name_length;
+    return tox->m->name_length;
 }
 
-int m_set_statusmessage(Messenger *m, const uint8_t *status, uint16_t length)
+int m_set_statusmessage(Tox *tox, const uint8_t *status, uint16_t length)
 {
     if (length > MAX_STATUSMESSAGE_LENGTH)
         return -1;
 
-    if (m->statusmessage_length == length && (length == 0 || memcmp(m->statusmessage, status, length) == 0))
+    if (tox->m->statusmessage_length == length && (length == 0 || memcmp(tox->m->statusmessage, status, length) == 0))
         return 0;
 
     if (length)
-        memcpy(m->statusmessage, status, length);
+        memcpy(tox->m->statusmessage, status, length);
 
-    m->statusmessage_length = length;
+    tox->m->statusmessage_length = length;
 
     uint32_t i;
 
-    for (i = 0; i < m->numfriends; ++i)
-        m->friendlist[i].statusmessage_sent = 0;
+    for (i = 0; i < tox->m->numfriends; ++i)
+        tox->m->friendlist[i].statusmessage_sent = 0;
 
     return 0;
 }
 
-int m_set_userstatus(Messenger *m, uint8_t status)
+int m_set_userstatus(Tox *tox, uint8_t status)
 {
     if (status >= USERSTATUS_INVALID)
         return -1;
 
-    if (m->userstatus == status)
+    if (tox->m->userstatus == status)
         return 0;
 
-    m->userstatus = status;
+    tox->m->userstatus = status;
     uint32_t i;
 
-    for (i = 0; i < m->numfriends; ++i)
-        m->friendlist[i].userstatus_sent = 0;
+    for (i = 0; i < tox->m->numfriends; ++i)
+        tox->m->friendlist[i].userstatus_sent = 0;
 
     return 0;
 }
 
 /* return the size of friendnumber's user status.
  * Guaranteed to be at most MAX_STATUSMESSAGE_LENGTH.
+ *
+ *      -- But it's not though...
  */
-int m_get_statusmessage_size(const Messenger *m, int32_t friendnumber)
+int m_get_statusmessage_size(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    return m->friendlist[friendnumber].statusmessage_length;
+    return tox->m->friendlist[friendnumber].statusmessage_length;
 }
 
 /*  Copy the user status of friendnumber into buf, truncating if needed to maxlen
  *  bytes, use m_get_statusmessage_size to find out how much you need to allocate.
  */
-int m_copy_statusmessage(const Messenger *m, int32_t friendnumber, uint8_t *buf, uint32_t maxlen)
+int m_copy_statusmessage(const Tox *tox, int32_t friendnumber, uint8_t *buf, uint32_t maxlen)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    int msglen = MIN(maxlen, m->friendlist[friendnumber].statusmessage_length);
+    int msglen = MIN(maxlen, tox->m->friendlist[friendnumber].statusmessage_length);
 
-    memcpy(buf, m->friendlist[friendnumber].statusmessage, msglen);
+    memcpy(buf, tox->m->friendlist[friendnumber].statusmessage, msglen);
     memset(buf + msglen, 0, maxlen - msglen);
     return msglen;
 }
@@ -656,23 +691,23 @@ int m_copy_statusmessage(const Messenger *m, int32_t friendnumber, uint8_t *buf,
 /* return the size of friendnumber's user status.
  * Guaranteed to be at most MAX_STATUSMESSAGE_LENGTH.
  */
-int m_get_self_statusmessage_size(const Messenger *m)
+int m_get_self_statusmessage_size(const Tox *tox)
 {
-    return m->statusmessage_length;
+    return tox->m->statusmessage_length;
 }
 
-int m_copy_self_statusmessage(const Messenger *m, uint8_t *buf)
+int m_copy_self_statusmessage(const Tox *tox, uint8_t *buf)
 {
-    memcpy(buf, m->statusmessage, m->statusmessage_length);
-    return m->statusmessage_length;
+    memcpy(buf, tox->m->statusmessage, tox->m->statusmessage_length);
+    return tox->m->statusmessage_length;
 }
 
-uint8_t m_get_userstatus(const Messenger *m, int32_t friendnumber)
+uint8_t m_get_userstatus(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return USERSTATUS_INVALID;
 
-    uint8_t status = m->friendlist[friendnumber].userstatus;
+    uint8_t status = tox->m->friendlist[friendnumber].userstatus;
 
     if (status >= USERSTATUS_INVALID) {
         status = USERSTATUS_NONE;
@@ -681,62 +716,62 @@ uint8_t m_get_userstatus(const Messenger *m, int32_t friendnumber)
     return status;
 }
 
-uint8_t m_get_self_userstatus(const Messenger *m)
+uint8_t m_get_self_userstatus(const Tox *tox)
 {
-    return m->userstatus;
+    return tox->m->userstatus;
 }
 
-uint64_t m_get_last_online(const Messenger *m, int32_t friendnumber)
+uint64_t m_get_last_online(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return UINT64_MAX;
 
-    return m->friendlist[friendnumber].last_seen_time;
+    return tox->m->friendlist[friendnumber].last_seen_time;
 }
 
-int m_set_usertyping(Messenger *m, int32_t friendnumber, uint8_t is_typing)
+int m_set_usertyping(Tox *tox, int32_t friendnumber, uint8_t is_typing)
 
 {
     if (is_typing != 0 && is_typing != 1)
         return -1;
 
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    if (m->friendlist[friendnumber].user_istyping == is_typing)
+    if (tox->m->friendlist[friendnumber].user_istyping == is_typing)
         return 0;
 
-    m->friendlist[friendnumber].user_istyping = is_typing;
-    m->friendlist[friendnumber].user_istyping_sent = 0;
+    tox->m->friendlist[friendnumber].user_istyping = is_typing;
+    tox->m->friendlist[friendnumber].user_istyping_sent = 0;
 
     return 0;
 }
 
-int m_get_istyping(const Messenger *m, int32_t friendnumber)
+int m_get_istyping(const Tox *tox, int32_t friendnumber)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    return m->friendlist[friendnumber].is_typing;
+    return tox->m->friendlist[friendnumber].is_typing;
 }
 
-static int send_statusmessage(const Messenger *m, int32_t friendnumber, const uint8_t *status, uint16_t length)
+static bool send_statusmessage(const Tox *tox, int32_t fr_num, const uint8_t *status, uint16_t length)
 {
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_STATUSMESSAGE, status, length, 0);
+    return write_cryptpacket_id(tox, fr_num, PACKET_ID_STATUSMESSAGE, status, length, 0);
 }
 
-static int send_userstatus(const Messenger *m, int32_t friendnumber, uint8_t status)
+static bool send_userstatus(const Tox *tox, int32_t fr_num, uint8_t status)
 {
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_USERSTATUS, &status, sizeof(status), 0);
+    return write_cryptpacket_id(tox, fr_num, PACKET_ID_USERSTATUS, &status, sizeof(status), 0);
 }
 
-static int send_user_istyping(const Messenger *m, int32_t friendnumber, uint8_t is_typing)
+static bool send_user_istyping(const Tox *tox, int32_t fr_num, uint8_t is_typing)
 {
     uint8_t typing = is_typing;
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_TYPING, &typing, sizeof(typing), 0);
+    return write_cryptpacket_id(tox, fr_num, PACKET_ID_TYPING, &typing, sizeof(typing), 0);
 }
 
-static int set_friend_statusmessage(const Messenger *m, int32_t friendnumber, const uint8_t *status, uint16_t length)
+int set_friend_statusmessage(const Messenger *m, int32_t friendnumber, const uint8_t *status, uint16_t length)
 {
     if (friend_not_valid(m, friendnumber))
         return -1;
@@ -751,7 +786,7 @@ static int set_friend_statusmessage(const Messenger *m, int32_t friendnumber, co
     return 0;
 }
 
-static void set_friend_userstatus(const Messenger *m, int32_t friendnumber, uint8_t status)
+void set_friend_userstatus(const Messenger *m, int32_t friendnumber, uint8_t status)
 {
     m->friendlist[friendnumber].userstatus = status;
 }
@@ -762,78 +797,78 @@ static void set_friend_typing(const Messenger *m, int32_t friendnumber, uint8_t 
 }
 
 /* Set the function that will be executed when a friend request is received. */
-void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, const uint8_t *, size_t,
+void m_callback_friendrequest(Tox *tox, void (*function)(Tox *tox, const uint8_t *, const uint8_t *, size_t,
                               void *), void *userdata)
 {
     void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, size_t, void *) = (void *)function;
-    callback_friendrequest(&(m->fr), handle_friendrequest, m, userdata);
+    callback_friendrequest(&(tox->m->fr), handle_friendrequest, tox->m, userdata);
 }
 
 /* Set the function that will be executed when a message from a friend is received. */
-void m_callback_friendmessage(Messenger *m, void (*function)(Messenger *m, uint32_t, unsigned int, const uint8_t *,
+void m_callback_friendmessage(Tox *tox, void (*function)(Tox *tox, uint32_t, unsigned int, const uint8_t *,
                               size_t, void *), void *userdata)
 {
-    m->friend_message = function;
-    m->friend_message_userdata = userdata;
+    tox->m->friend_message = function;
+    tox->m->friend_message_userdata = userdata;
 }
 
-void m_callback_namechange(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, size_t, void *),
+void m_callback_namechange(Tox *tox, void (*function)(Tox *tox, uint32_t, const uint8_t *, size_t, void *),
                            void *userdata)
 {
-    m->friend_namechange = function;
-    m->friend_namechange_userdata = userdata;
+    tox->m->friend_namechange = function;
+    tox->m->friend_namechange_userdata = userdata;
 }
 
-void m_callback_statusmessage(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, size_t, void *),
+void m_callback_statusmessage(Tox *tox, void (*function)(Tox *tox, uint32_t, const uint8_t *, size_t, void *),
                               void *userdata)
 {
-    m->friend_statusmessagechange = function;
-    m->friend_statusmessagechange_userdata = userdata;
+    tox->m->friend_statusmessagechange = function;
+    tox->m->friend_statusmessagechange_userdata = userdata;
 }
 
-void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, uint32_t, unsigned int, void *), void *userdata)
+void m_callback_userstatus(Tox *tox, void (*function)(Tox *tox, uint32_t, unsigned int, void *), void *userdata)
 {
-    m->friend_userstatuschange = function;
-    m->friend_userstatuschange_userdata = userdata;
+    tox->m->friend_userstatuschange = function;
+    tox->m->friend_userstatuschange_userdata = userdata;
 }
 
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, _Bool, void *), void *userdata)
+void m_callback_typingchange(Tox *tox, void(*function)(Tox *tox, uint32_t, _Bool, void *), void *userdata)
 {
-    m->friend_typingchange = function;
-    m->friend_typingchange_userdata = userdata;
+    tox->m->friend_typingchange = function;
+    tox->m->friend_typingchange_userdata = userdata;
 }
 
-void m_callback_read_receipt(Messenger *m, void (*function)(Messenger *m, uint32_t, uint32_t, void *), void *userdata)
+void m_callback_read_receipt(Tox *tox, void (*function)(Tox *tox, uint32_t, uint32_t, void *), void *userdata)
 {
-    m->read_receipt = function;
-    m->read_receipt_userdata = userdata;
+    tox->m->read_receipt = function;
+    tox->m->read_receipt_userdata = userdata;
 }
 
-void m_callback_connectionstatus(Messenger *m, void (*function)(Messenger *m, uint32_t, unsigned int, void *),
+void m_callback_connectionstatus(Tox *tox, void (*function)(Tox *tox, uint32_t, unsigned int, void *),
                                  void *userdata)
 {
-    m->friend_connectionstatuschange = function;
-    m->friend_connectionstatuschange_userdata = userdata;
+    tox->m->friend_connectionstatuschange = function;
+    tox->m->friend_connectionstatuschange_userdata = userdata;
 }
 
-void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, unsigned int, void *), void *userdata)
+void m_callback_core_connection(Tox *tox, void (*function)(Tox *tox, unsigned int, void *), void *userdata)
 {
-    m->core_connection_change = function;
-    m->core_connection_change_userdata = userdata;
+    tox->m->core_connection_change = function;
+    tox->m->core_connection_change_userdata = userdata;
 }
 
-void m_callback_connectionstatus_internal_av(Messenger *m, void (*function)(Messenger *m, uint32_t, uint8_t, void *),
+void m_callback_connectionstatus_internal_av(Tox *tox, void (*function)(Tox *tox, uint32_t, uint8_t, void *),
         void *userdata)
 {
-    m->friend_connectionstatuschange_internal = function;
-    m->friend_connectionstatuschange_internal_userdata = userdata;
+    tox->m->friend_connectionstatuschange_internal = function;
+    tox->m->friend_connectionstatuschange_internal_userdata = userdata;
 }
 
-static void check_friend_tcp_udp(Messenger *m, int32_t friendnumber)
+static void check_friend_tcp_udp(Tox *tox, int32_t friendnumber)
 {
-    int last_connection_udp_tcp = m->friendlist[friendnumber].last_connection_udp_tcp;
+    int last_connection_udp_tcp = tox->m->friendlist[friendnumber].last_connection_udp_tcp;
 
-    int ret = m_get_friend_connectionstatus(m, friendnumber);
+    int ret = m_get_friend_connectionstatus(tox, friendnumber);
 
     if (ret == -1)
         return;
@@ -847,56 +882,57 @@ static void check_friend_tcp_udp(Messenger *m, int32_t friendnumber)
     }
 
     if (last_connection_udp_tcp != ret) {
-        if (m->friend_connectionstatuschange)
-            m->friend_connectionstatuschange(m, friendnumber, ret, m->friend_connectionstatuschange_userdata);
+        if (tox->m->friend_connectionstatuschange)
+            tox->m->friend_connectionstatuschange(tox, friendnumber, ret, tox->m->friend_connectionstatuschange_userdata);
     }
 
-    m->friendlist[friendnumber].last_connection_udp_tcp = ret;
+    tox->m->friendlist[friendnumber].last_connection_udp_tcp = ret;
 }
 
 static void break_files(const Messenger *m, int32_t friendnumber);
-static void check_friend_connectionstatus(Messenger *m, int32_t friendnumber, uint8_t status)
+static void check_friend_connectionstatus(Tox *tox, int32_t friendnumber, uint8_t status)
 {
     if (status == NOFRIEND)
         return;
 
-    const uint8_t was_online = m->friendlist[friendnumber].status == FRIEND_ONLINE;
+    const uint8_t was_online = tox->m->friendlist[friendnumber].status == FRIEND_ONLINE;
     const uint8_t is_online = status == FRIEND_ONLINE;
 
     if (is_online != was_online) {
         if (was_online) {
-            break_files(m, friendnumber);
-            clear_receipts(m, friendnumber);
+            break_files(tox->m, friendnumber);
+            clear_receipts(tox->m, friendnumber);
         } else {
-            m->friendlist[friendnumber].name_sent = 0;
-            m->friendlist[friendnumber].userstatus_sent = 0;
-            m->friendlist[friendnumber].statusmessage_sent = 0;
-            m->friendlist[friendnumber].user_istyping_sent = 0;
+            /* Friend just came online, reset every variable we need to send them */
+            tox->m->friendlist[friendnumber].name_sent = 0;
+            tox->m->friendlist[friendnumber].userstatus_sent = 0;
+            tox->m->friendlist[friendnumber].statusmessage_sent = 0;
+            tox->m->friendlist[friendnumber].user_istyping_sent = 0;
         }
 
-        m->friendlist[friendnumber].status = status;
+        tox->m->friendlist[friendnumber].status = status;
 
-        check_friend_tcp_udp(m, friendnumber);
-
-        if (m->friend_connectionstatuschange_internal)
-            m->friend_connectionstatuschange_internal(m, friendnumber, is_online,
-                    m->friend_connectionstatuschange_internal_userdata);
+        if (tox->m->friend_connectionstatuschange_internal)
+            tox->m->friend_connectionstatuschange_internal(tox, friendnumber, is_online,
+                    tox->m->friend_connectionstatuschange_internal_userdata);
     }
+
+    check_friend_tcp_udp(tox, friendnumber);
 }
 
-void set_friend_status(Messenger *m, int32_t friendnumber, uint8_t status)
+void set_friend_status(Tox *tox, int32_t friendnumber, uint8_t status)
 {
-    check_friend_connectionstatus(m, friendnumber, status);
-    m->friendlist[friendnumber].status = status;
+    check_friend_connectionstatus(tox, friendnumber, status);
+    tox->m->friendlist[friendnumber].status = status;
 }
 
-static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_t packet_id, const uint8_t *data,
-                                uint32_t length, uint8_t congestion_control)
+static int write_cryptpacket_id(const Tox *tox, int32_t fr_num, uint8_t packet_id,
+                                const uint8_t *data, uint32_t length, uint8_t congestion_control)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, fr_num))
         return 0;
 
-    if (length >= MAX_CRYPTO_DATA_SIZE || m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (length >= MAX_CRYPTO_DATA_SIZE || tox->m->friendlist[fr_num].status != FRIEND_ONLINE)
         return 0;
 
     uint8_t packet[length + 1];
@@ -905,8 +941,10 @@ static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_
     if (length != 0)
         memcpy(packet + 1, data, length);
 
-    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                             m->friendlist[friendnumber].friendcon_id), packet, length + 1, congestion_control) != -1;
+    return write_cryptpacket(tox->net_crypto,
+                             toxconn_crypt_connection_id(tox->tox_conn,
+                                                         tox->m->friendlist[fr_num].friendcon_id),
+                             packet, length + 1, congestion_control) != -1;
 }
 
 /**********GROUP CHATS************/
@@ -914,11 +952,11 @@ static int write_cryptpacket_id(const Messenger *m, int32_t friendnumber, uint8_
 
 /* Set the callback for group invites.
  *
- *  Function(Messenger *m, uint32_t friendnumber, uint8_t *data, uint16_t length)
+ *  Function(Tox *tox, uint32_t friendnumber, uint8_t *data, uint16_t length)
  */
-void m_callback_group_invite(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, uint16_t))
+void m_callback_group_invite(Tox *tox, void (*function)(Tox *tox, uint32_t, const uint8_t *, uint16_t))
 {
-    m->group_invite = function;
+    tox->m->group_invite = function;
 }
 
 
@@ -927,9 +965,9 @@ void m_callback_group_invite(Messenger *m, void (*function)(Messenger *m, uint32
  *  return 1 on success
  *  return 0 on failure
  */
-int send_group_invite_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length)
+int send_group_invite_packet(const Tox *tox, int32_t friendnumber, const uint8_t *data, uint16_t length)
 {
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_INVITE_GROUPCHAT, data, length, 0);
+    return write_cryptpacket_id(tox, friendnumber, PACKET_ID_INVITE_GROUPCHAT, data, length, 0);
 }
 
 /****************FILE SENDING*****************/
@@ -939,11 +977,11 @@ int send_group_invite_packet(const Messenger *m, int32_t friendnumber, const uin
  *
  *  Function(Tox *tox, uint32_t friendnumber, uint32_t filenumber, uint32_t filetype, uint64_t filesize, uint8_t *filename, size_t filename_length, void *userdata)
  */
-void callback_file_sendrequest(Messenger *m, void (*function)(Messenger *m,  uint32_t, uint32_t, uint32_t, uint64_t,
+void callback_file_sendrequest(Tox *tox, void (*function)(Tox *tox,  uint32_t, uint32_t, uint32_t, uint64_t,
                                const uint8_t *, size_t, void *), void *userdata)
 {
-    m->file_sendrequest = function;
-    m->file_sendrequest_userdata = userdata;
+    tox->m->file_sendrequest = function;
+    tox->m->file_sendrequest_userdata = userdata;
 }
 
 /* Set the callback for file control requests.
@@ -951,11 +989,11 @@ void callback_file_sendrequest(Messenger *m, void (*function)(Messenger *m,  uin
  *  Function(Tox *tox, uint32_t friendnumber, uint32_t filenumber, unsigned int control_type, void *userdata)
  *
  */
-void callback_file_control(Messenger *m, void (*function)(Messenger *m, uint32_t, uint32_t, unsigned int, void *),
+void callback_file_control(Tox *tox, void (*function)(Tox *tox, uint32_t, uint32_t, unsigned int, void *),
                            void *userdata)
 {
-    m->file_filecontrol = function;
-    m->file_filecontrol_userdata = userdata;
+    tox->m->file_filecontrol = function;
+    tox->m->file_filecontrol_userdata = userdata;
 }
 
 /* Set the callback for file data.
@@ -963,11 +1001,11 @@ void callback_file_control(Messenger *m, void (*function)(Messenger *m, uint32_t
  *  Function(Tox *tox, uint32_t friendnumber, uint32_t filenumber, uint64_t position, uint8_t *data, size_t length, void *userdata)
  *
  */
-void callback_file_data(Messenger *m, void (*function)(Messenger *m, uint32_t, uint32_t, uint64_t, const uint8_t *,
+void callback_file_data(Tox *tox, void (*function)(Tox *tox, uint32_t, uint32_t, uint64_t, const uint8_t *,
                         size_t, void *), void *userdata)
 {
-    m->file_filedata = function;
-    m->file_filedata_userdata = userdata;
+    tox->m->file_filedata = function;
+    tox->m->file_filedata_userdata = userdata;
 }
 
 /* Set the callback for file request chunk.
@@ -975,11 +1013,11 @@ void callback_file_data(Messenger *m, void (*function)(Messenger *m, uint32_t, u
  *  Function(Tox *tox, uint32_t friendnumber, uint32_t filenumber, uint64_t position, size_t length, void *userdata)
  *
  */
-void callback_file_reqchunk(Messenger *m, void (*function)(Messenger *m, uint32_t, uint32_t, uint64_t, size_t, void *),
+void callback_file_reqchunk(Tox *tox, void (*function)(Tox *tox, uint32_t, uint32_t, uint64_t, size_t, void *),
                             void *userdata)
 {
-    m->file_reqchunk = function;
-    m->file_reqchunk_userdata = userdata;
+    tox->m->file_reqchunk = function;
+    tox->m->file_reqchunk_userdata = userdata;
 }
 
 #define MAX_FILENAME_LENGTH 255
@@ -990,12 +1028,12 @@ void callback_file_reqchunk(Messenger *m, void (*function)(Messenger *m, uint32_
  * return -1 if friend not valid.
  * return -2 if filenumber not valid
  */
-int file_get_id(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint8_t *file_id)
+int file_get_id(const Tox *tox, int32_t friendnumber, uint32_t filenumber, uint8_t *file_id)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (tox->m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -2;
 
     uint32_t temp_filenum;
@@ -1017,9 +1055,9 @@ int file_get_id(const Messenger *m, int32_t friendnumber, uint32_t filenumber, u
     struct File_Transfers *ft;
 
     if (send_receive) {
-        ft = &m->friendlist[friendnumber].file_receiving[file_number];
+        ft = &tox->m->friendlist[friendnumber].file_receiving[file_number];
     } else {
-        ft = &m->friendlist[friendnumber].file_sending[file_number];
+        ft = &tox->m->friendlist[friendnumber].file_sending[file_number];
     }
 
     if (ft->status == FILESTATUS_NONE)
@@ -1034,10 +1072,10 @@ int file_get_id(const Messenger *m, int32_t friendnumber, uint32_t filenumber, u
  *  return 1 on success
  *  return 0 on failure
  */
-static int file_sendrequest(const Messenger *m, int32_t friendnumber, uint8_t filenumber, uint32_t file_type,
+static int file_sendrequest(const Tox *tox, int32_t friendnumber, uint8_t filenumber, uint32_t file_type,
                             uint64_t filesize, const uint8_t *file_id, const uint8_t *filename, uint16_t filename_length)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return 0;
 
     if (filename_length > MAX_FILENAME_LENGTH)
@@ -1055,7 +1093,7 @@ static int file_sendrequest(const Messenger *m, int32_t friendnumber, uint8_t fi
         memcpy(packet + 1 + sizeof(file_type) + sizeof(filesize) + FILE_ID_LENGTH, filename, filename_length);
     }
 
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_FILE_SENDREQUEST, packet, sizeof(packet), 0);
+    return write_cryptpacket_id(tox, friendnumber, PACKET_ID_FILE_SENDREQUEST, packet, sizeof(packet), 0);
 }
 
 /* Send a file send request.
@@ -1067,10 +1105,10 @@ static int file_sendrequest(const Messenger *m, int32_t friendnumber, uint8_t fi
  *  return -4 if could not send packet (friend offline).
  *
  */
-long int new_filesender(const Messenger *m, int32_t friendnumber, uint32_t file_type, uint64_t filesize,
+long int new_filesender(const Tox *tox, int32_t friendnumber, uint32_t file_type, uint64_t filesize,
                         const uint8_t *file_id, const uint8_t *filename, uint16_t filename_length)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
     if (filename_length > MAX_FILENAME_LENGTH)
@@ -1079,17 +1117,17 @@ long int new_filesender(const Messenger *m, int32_t friendnumber, uint32_t file_
     uint32_t i;
 
     for (i = 0; i < MAX_CONCURRENT_FILE_PIPES; ++i) {
-        if (m->friendlist[friendnumber].file_sending[i].status == FILESTATUS_NONE)
+        if (tox->m->friendlist[friendnumber].file_sending[i].status == FILESTATUS_NONE)
             break;
     }
 
     if (i == MAX_CONCURRENT_FILE_PIPES)
         return -3;
 
-    if (file_sendrequest(m, friendnumber, i, file_type, filesize, file_id, filename, filename_length) == 0)
+    if (file_sendrequest(tox, friendnumber, i, file_type, filesize, file_id, filename, filename_length) == 0)
         return -4;
 
-    struct File_Transfers *ft = &m->friendlist[friendnumber].file_sending[i];
+    struct File_Transfers *ft = &tox->m->friendlist[friendnumber].file_sending[i];
     ft->status = FILESTATUS_NOT_ACCEPTED;
     ft->size = filesize;
     ft->transferred = 0;
@@ -1098,12 +1136,12 @@ long int new_filesender(const Messenger *m, int32_t friendnumber, uint32_t file_
     ft->paused = FILE_PAUSE_NOT;
     memcpy(ft->id, file_id, FILE_ID_LENGTH);
 
-    ++m->friendlist[friendnumber].num_sending_files;
+    ++tox->m->friendlist[friendnumber].num_sending_files;
 
     return i;
 }
 
-int send_file_control_packet(const Messenger *m, int32_t friendnumber, uint8_t send_receive, uint8_t filenumber,
+int send_file_control_packet(const Tox *tox, int32_t friendnumber, uint8_t send_receive, uint8_t filenumber,
                              uint8_t control_type, uint8_t *data, uint16_t data_length)
 {
     if ((unsigned int)(1 + 3 + data_length) > MAX_CRYPTO_DATA_SIZE)
@@ -1119,7 +1157,7 @@ int send_file_control_packet(const Messenger *m, int32_t friendnumber, uint8_t s
         memcpy(packet + 3, data, data_length);
     }
 
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_FILE_CONTROL, packet, sizeof(packet), 0);
+    return write_cryptpacket_id(tox, friendnumber, PACKET_ID_FILE_CONTROL, packet, sizeof(packet), 0);
 }
 
 /* Send a file control request.
@@ -1134,12 +1172,12 @@ int send_file_control_packet(const Messenger *m, int32_t friendnumber, uint8_t s
  *  return -7 if resume file failed because it wasn't paused.
  *  return -8 if packet failed to send.
  */
-int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, unsigned int control)
+int file_control(const Tox *tox, int32_t friendnumber, uint32_t filenumber, unsigned int control)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (tox->m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -2;
 
     uint32_t temp_filenum;
@@ -1161,9 +1199,9 @@ int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, 
     struct File_Transfers *ft;
 
     if (send_receive) {
-        ft = &m->friendlist[friendnumber].file_receiving[file_number];
+        ft = &tox->m->friendlist[friendnumber].file_receiving[file_number];
     } else {
-        ft = &m->friendlist[friendnumber].file_sending[file_number];
+        ft = &tox->m->friendlist[friendnumber].file_sending[file_number];
     }
 
     if (ft->status == FILESTATUS_NONE)
@@ -1193,12 +1231,12 @@ int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, 
         }
     }
 
-    if (send_file_control_packet(m, friendnumber, send_receive, file_number, control, 0, 0)) {
+    if (send_file_control_packet(tox, friendnumber, send_receive, file_number, control, 0, 0)) {
         if (control == FILECONTROL_KILL) {
             ft->status = FILESTATUS_NONE;
 
             if (send_receive == 0) {
-                --m->friendlist[friendnumber].num_sending_files;
+                --tox->m->friendlist[friendnumber].num_sending_files;
             }
         } else if (control == FILECONTROL_PAUSE) {
             ft->paused |= FILE_PAUSE_US;
@@ -1227,12 +1265,12 @@ int file_control(const Messenger *m, int32_t friendnumber, uint32_t filenumber, 
  *  return -6 if position bad.
  *  return -8 if packet failed to send.
  */
-int file_seek(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint64_t position)
+int file_seek(const Tox *tox, int32_t friendnumber, uint32_t filenumber, uint64_t position)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (tox->m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -2;
 
     uint32_t temp_filenum;
@@ -1253,9 +1291,9 @@ int file_seek(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
     struct File_Transfers *ft;
 
     if (send_receive) {
-        ft = &m->friendlist[friendnumber].file_receiving[file_number];
+        ft = &tox->m->friendlist[friendnumber].file_receiving[file_number];
     } else {
-        ft = &m->friendlist[friendnumber].file_sending[file_number];
+        ft = &tox->m->friendlist[friendnumber].file_sending[file_number];
     }
 
     if (ft->status == FILESTATUS_NONE)
@@ -1271,7 +1309,7 @@ int file_seek(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
     uint64_t sending_pos = position;
     host_to_net((uint8_t *)&sending_pos, sizeof(sending_pos));
 
-    if (send_file_control_packet(m, friendnumber, send_receive, file_number, FILECONTROL_SEEK, (uint8_t *)&sending_pos,
+    if (send_file_control_packet(tox, friendnumber, send_receive, file_number, FILECONTROL_SEEK, (uint8_t *)&sending_pos,
                                  sizeof(sending_pos))) {
         ft->transferred = position;
     } else {
@@ -1284,10 +1322,10 @@ int file_seek(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
 /* return packet number on success.
  * return -1 on failure.
  */
-static int64_t send_file_data_packet(const Messenger *m, int32_t friendnumber, uint8_t filenumber, const uint8_t *data,
+static int64_t send_file_data_packet(const Tox *tox, int32_t friendnumber, uint8_t filenumber, const uint8_t *data,
                                      uint16_t length)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
     uint8_t packet[2 + length];
@@ -1298,8 +1336,8 @@ static int64_t send_file_data_packet(const Messenger *m, int32_t friendnumber, u
         memcpy(packet + 2, data, length);
     }
 
-    return write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                             m->friendlist[friendnumber].friendcon_id), packet, sizeof(packet), 1);
+    return write_cryptpacket(tox->net_crypto, toxconn_crypt_connection_id(tox->tox_conn,
+                             tox->m->friendlist[friendnumber].friendcon_id), packet, sizeof(packet), 1);
 }
 
 #define MAX_FILE_DATA_SIZE (MAX_CRYPTO_DATA_SIZE - 2)
@@ -1315,19 +1353,19 @@ static int64_t send_file_data_packet(const Messenger *m, int32_t friendnumber, u
  *  return -6 if packet queue full.
  *  return -7 if wrong position.
  */
-int file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
+int file_data(const Tox *tox, int32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
               uint16_t length)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
-    if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (tox->m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -2;
 
     if (filenumber >= MAX_CONCURRENT_FILE_PIPES)
         return -3;
 
-    struct File_Transfers *ft = &m->friendlist[friendnumber].file_sending[filenumber];
+    struct File_Transfers *ft = &tox->m->friendlist[friendnumber].file_sending[filenumber];
 
     if (ft->status != FILESTATUS_TRANSFERRING)
         return -4;
@@ -1348,11 +1386,11 @@ int file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
     }
 
     /* Prevent file sending from filling up the entire buffer preventing messages from being sent. TODO: remove */
-    if (crypto_num_free_sendqueue_slots(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                                        m->friendlist[friendnumber].friendcon_id)) < MIN_SLOTS_FREE)
+    if (crypto_num_free_sendqueue_slots(tox->net_crypto, toxconn_crypt_connection_id(tox->tox_conn,
+                                        tox->m->friendlist[friendnumber].friendcon_id)) < MIN_SLOTS_FREE)
         return -6;
 
-    int64_t ret = send_file_data_packet(m, friendnumber, filenumber, data, length);
+    int64_t ret = send_file_data_packet(tox, friendnumber, filenumber, data, length);
 
     if (ret != -1) {
         //TODO record packet ids to check if other received complete file.
@@ -1381,33 +1419,33 @@ int file_data(const Messenger *m, int32_t friendnumber, uint32_t filenumber, uin
  *  return number of bytes remaining to be sent/received on success
  *  return 0 on failure
  */
-uint64_t file_dataremaining(const Messenger *m, int32_t friendnumber, uint8_t filenumber, uint8_t send_receive)
+uint64_t file_dataremaining(const Tox *tox, int32_t friendnumber, uint8_t filenumber, uint8_t send_receive)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return 0;
 
     if (send_receive == 0) {
-        if (m->friendlist[friendnumber].file_sending[filenumber].status == FILESTATUS_NONE)
+        if (tox->m->friendlist[friendnumber].file_sending[filenumber].status == FILESTATUS_NONE)
             return 0;
 
-        return m->friendlist[friendnumber].file_sending[filenumber].size -
-               m->friendlist[friendnumber].file_sending[filenumber].transferred;
+        return tox->m->friendlist[friendnumber].file_sending[filenumber].size -
+               tox->m->friendlist[friendnumber].file_sending[filenumber].transferred;
     } else {
-        if (m->friendlist[friendnumber].file_receiving[filenumber].status == FILESTATUS_NONE)
+        if (tox->m->friendlist[friendnumber].file_receiving[filenumber].status == FILESTATUS_NONE)
             return 0;
 
-        return m->friendlist[friendnumber].file_receiving[filenumber].size -
-               m->friendlist[friendnumber].file_receiving[filenumber].transferred;
+        return tox->m->friendlist[friendnumber].file_receiving[filenumber].size -
+               tox->m->friendlist[friendnumber].file_receiving[filenumber].transferred;
     }
 }
 
-static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
+static void do_reqchunk_filecb(Tox *tox, int32_t friendnumber)
 {
-    if (!m->friendlist[friendnumber].num_sending_files)
+    if (!tox->m->friendlist[friendnumber].num_sending_files)
         return;
 
-    int free_slots = crypto_num_free_sendqueue_slots(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                     m->friendlist[friendnumber].friendcon_id));
+    int free_slots = crypto_num_free_sendqueue_slots(tox->net_crypto, toxconn_crypt_connection_id(tox->tox_conn,
+                     tox->m->friendlist[friendnumber].friendcon_id));
 
     if (free_slots < MIN_SLOTS_FREE) {
         free_slots = 0;
@@ -1415,22 +1453,22 @@ static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
         free_slots -= MIN_SLOTS_FREE;
     }
 
-    unsigned int i, num = m->friendlist[friendnumber].num_sending_files;
+    unsigned int i, num = tox->m->friendlist[friendnumber].num_sending_files;
 
     for (i = 0; i < MAX_CONCURRENT_FILE_PIPES; ++i) {
-        struct File_Transfers *ft = &m->friendlist[friendnumber].file_sending[i];
+        struct File_Transfers *ft = &tox->m->friendlist[friendnumber].file_sending[i];
 
         if (ft->status != FILESTATUS_NONE) {
             --num;
 
             if (ft->status == FILESTATUS_FINISHED) {
                 /* Check if file was entirely sent. */
-                if (friend_received_packet(m, friendnumber, ft->last_packet_number) == 0) {
-                    if (m->file_reqchunk)
-                        (*m->file_reqchunk)(m, friendnumber, i, ft->transferred, 0, m->file_reqchunk_userdata);
+                if (friend_received_packet(tox, friendnumber, ft->last_packet_number) == 0) {
+                    if (tox->m->file_reqchunk)
+                        (*tox->m->file_reqchunk)(tox, friendnumber, i, ft->transferred, 0, tox->m->file_reqchunk_userdata);
 
                     ft->status = FILESTATUS_NONE;
-                    --m->friendlist[friendnumber].num_sending_files;
+                    --tox->m->friendlist[friendnumber].num_sending_files;
                 }
             }
 
@@ -1443,8 +1481,8 @@ static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
         }
 
         while (ft->status == FILESTATUS_TRANSFERRING && (ft->paused == FILE_PAUSE_NOT)) {
-            if (max_speed_reached(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                                  m->friendlist[friendnumber].friendcon_id))) {
+            if (max_speed_reached(tox->net_crypto, toxconn_crypt_connection_id(tox->tox_conn,
+                                  tox->m->friendlist[friendnumber].friendcon_id))) {
                 free_slots = 0;
             }
 
@@ -1455,7 +1493,7 @@ static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
 
             if (ft->size == 0) {
                 /* Send 0 data to friend if file is 0 length. */
-                file_data(m, friendnumber, i, 0, 0, 0);
+                file_data(tox, friendnumber, i, 0, 0, 0);
                 break;
             }
 
@@ -1472,8 +1510,8 @@ static void do_reqchunk_filecb(Messenger *m, int32_t friendnumber)
             uint64_t position = ft->requested;
             ft->requested += length;
 
-            if (m->file_reqchunk)
-                (*m->file_reqchunk)(m, friendnumber, i, position, length, m->file_reqchunk_userdata);
+            if (tox->m->file_reqchunk)
+                (*tox->m->file_reqchunk)(tox, friendnumber, i, position, length, tox->m->file_reqchunk_userdata);
 
             --free_slots;
 
@@ -1503,7 +1541,7 @@ static void break_files(const Messenger *m, int32_t friendnumber)
 
 /* return -1 on failure, 0 on success.
  */
-static int handle_filecontrol(Messenger *m, int32_t friendnumber, uint8_t receive_send, uint8_t filenumber,
+static int handle_filecontrol(Tox *tox, int32_t friendnumber, uint8_t receive_send, uint8_t filenumber,
                               uint8_t control_type, uint8_t *data, uint16_t length)
 {
     if (receive_send > 1)
@@ -1518,14 +1556,14 @@ static int handle_filecontrol(Messenger *m, int32_t friendnumber, uint8_t receiv
     if (receive_send == 0) {
         real_filenumber += 1;
         real_filenumber <<= 16;
-        ft = &m->friendlist[friendnumber].file_receiving[filenumber];
+        ft = &tox->m->friendlist[friendnumber].file_receiving[filenumber];
     } else {
-        ft = &m->friendlist[friendnumber].file_sending[filenumber];
+        ft = &tox->m->friendlist[friendnumber].file_sending[filenumber];
     }
 
     if (ft->status == FILESTATUS_NONE) {
         /* File transfer doesn't exist, tell the other to kill it. */
-        send_file_control_packet(m, friendnumber, !receive_send, filenumber, FILECONTROL_KILL, 0, 0);
+        send_file_control_packet(tox, friendnumber, !receive_send, filenumber, FILECONTROL_KILL, 0, 0);
         return -1;
     }
 
@@ -1540,8 +1578,8 @@ static int handle_filecontrol(Messenger *m, int32_t friendnumber, uint8_t receiv
             }
         }
 
-        if (m->file_filecontrol)
-            (*m->file_filecontrol)(m, friendnumber, real_filenumber, control_type, m->file_filecontrol_userdata);
+        if (tox->m->file_filecontrol)
+            (*tox->m->file_filecontrol)(tox, friendnumber, real_filenumber, control_type, tox->m->file_filecontrol_userdata);
     } else if (control_type == FILECONTROL_PAUSE) {
         if ((ft->paused & FILE_PAUSE_OTHER) || ft->status != FILESTATUS_TRANSFERRING) {
             return -1;
@@ -1549,17 +1587,17 @@ static int handle_filecontrol(Messenger *m, int32_t friendnumber, uint8_t receiv
 
         ft->paused |= FILE_PAUSE_OTHER;
 
-        if (m->file_filecontrol)
-            (*m->file_filecontrol)(m, friendnumber, real_filenumber, control_type, m->file_filecontrol_userdata);
+        if (tox->m->file_filecontrol)
+            (*tox->m->file_filecontrol)(tox, friendnumber, real_filenumber, control_type, tox->m->file_filecontrol_userdata);
     } else if (control_type == FILECONTROL_KILL) {
 
-        if (m->file_filecontrol)
-            (*m->file_filecontrol)(m, friendnumber, real_filenumber, control_type, m->file_filecontrol_userdata);
+        if (tox->m->file_filecontrol)
+            (*tox->m->file_filecontrol)(tox, friendnumber, real_filenumber, control_type, tox->m->file_filecontrol_userdata);
 
         ft->status = FILESTATUS_NONE;
 
         if (receive_send) {
-            --m->friendlist[friendnumber].num_sending_files;
+            --tox->m->friendlist[friendnumber].num_sending_files;
         }
 
     } else if (control_type == FILECONTROL_SEEK) {
@@ -1593,13 +1631,13 @@ static int handle_filecontrol(Messenger *m, int32_t friendnumber, uint8_t receiv
 
 /* Set the callback for msi packets.
  *
- *  Function(Messenger *m, int friendnumber, uint8_t *data, uint16_t length, void *userdata)
+ *  Function(Tox *tox, int friendnumber, uint8_t *data, uint16_t length, void *userdata)
  */
-void m_callback_msi_packet(Messenger *m, void (*function)(Messenger *m, uint32_t, const uint8_t *, uint16_t, void *),
+void m_callback_msi_packet(Tox *tox, void (*function)(Tox *tox, uint32_t, const uint8_t *, uint16_t, void *),
                            void *userdata)
 {
-    m->msi_packet = function;
-    m->msi_packet_userdata = userdata;
+    tox->m->msi_packet = function;
+    tox->m->msi_packet_userdata = userdata;
 }
 
 /* Send an msi packet.
@@ -1607,44 +1645,44 @@ void m_callback_msi_packet(Messenger *m, void (*function)(Messenger *m, uint32_t
  *  return 1 on success
  *  return 0 on failure
  */
-int m_msi_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint16_t length)
+int m_msi_packet(const Tox *tox, int32_t friendnumber, const uint8_t *data, uint16_t length)
 {
-    return write_cryptpacket_id(m, friendnumber, PACKET_ID_MSI, data, length, 0);
+    return write_cryptpacket_id(tox, friendnumber, PACKET_ID_MSI, data, length, 0);
 }
 
 static int handle_custom_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length)
 {
-    Messenger *m = object;
+    Tox *tox = object;
 
-    if (friend_not_valid(m, friend_num))
+    if (friend_not_valid(tox->m, friend_num))
         return 1;
 
     if (packet[0] < (PACKET_ID_LOSSY_RANGE_START + PACKET_LOSSY_AV_RESERVED)) {
-        if (m->friendlist[friend_num].lossy_rtp_packethandlers[packet[0] % PACKET_LOSSY_AV_RESERVED].function)
-            return m->friendlist[friend_num].lossy_rtp_packethandlers[packet[0] % PACKET_LOSSY_AV_RESERVED].function(
-                       m, friend_num, packet, length, m->friendlist[friend_num].lossy_rtp_packethandlers[packet[0] %
+        if (tox->m->friendlist[friend_num].lossy_rtp_packethandlers[packet[0] % PACKET_LOSSY_AV_RESERVED].function)
+            return tox->m->friendlist[friend_num].lossy_rtp_packethandlers[packet[0] % PACKET_LOSSY_AV_RESERVED].function(
+                       tox, friend_num, packet, length, tox->m->friendlist[friend_num].lossy_rtp_packethandlers[packet[0] %
                                PACKET_LOSSY_AV_RESERVED].object);
 
         return 1;
     }
 
-    if (m->lossy_packethandler)
-        m->lossy_packethandler(m, friend_num, packet, length, m->lossy_packethandler_userdata);
+    if (tox->m->lossy_packethandler)
+        tox->m->lossy_packethandler(tox, friend_num, packet, length, tox->m->lossy_packethandler_userdata);
 
     return 1;
 }
 
-void custom_lossy_packet_registerhandler(Messenger *m, void (*packet_handler_callback)(Messenger *m,
+void custom_lossy_packet_registerhandler(Tox *tox, void (*packet_handler_callback)(Tox *tox,
         uint32_t friendnumber, const uint8_t *data, size_t len, void *object), void *object)
 {
-    m->lossy_packethandler = packet_handler_callback;
-    m->lossy_packethandler_userdata = object;
+    tox->m->lossy_packethandler = packet_handler_callback;
+    tox->m->lossy_packethandler_userdata = object;
 }
 
-int m_callback_rtp_packet(Messenger *m, int32_t friendnumber, uint8_t byte, int (*packet_handler_callback)(Messenger *m,
+int m_callback_rtp_packet(Tox *tox, int32_t friendnumber, uint8_t byte, int (*packet_handler_callback)(Tox *tox,
                           uint32_t friendnumber, const uint8_t *data, uint16_t len, void *object), void *object)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
     if (byte < PACKET_ID_LOSSY_RANGE_START)
@@ -1653,16 +1691,16 @@ int m_callback_rtp_packet(Messenger *m, int32_t friendnumber, uint8_t byte, int 
     if (byte >= (PACKET_ID_LOSSY_RANGE_START + PACKET_LOSSY_AV_RESERVED))
         return -1;
 
-    m->friendlist[friendnumber].lossy_rtp_packethandlers[byte % PACKET_LOSSY_AV_RESERVED].function =
+    tox->m->friendlist[friendnumber].lossy_rtp_packethandlers[byte % PACKET_LOSSY_AV_RESERVED].function =
         packet_handler_callback;
-    m->friendlist[friendnumber].lossy_rtp_packethandlers[byte % PACKET_LOSSY_AV_RESERVED].object = object;
+    tox->m->friendlist[friendnumber].lossy_rtp_packethandlers[byte % PACKET_LOSSY_AV_RESERVED].object = object;
     return 0;
 }
 
 
-int send_custom_lossy_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint32_t length)
+int send_custom_lossy_packet(const Tox *tox, int32_t friendnumber, const uint8_t *data, uint32_t length)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
     if (length == 0 || length > MAX_CRYPTO_DATA_SIZE)
@@ -1674,11 +1712,11 @@ int send_custom_lossy_packet(const Messenger *m, int32_t friendnumber, const uin
     if (data[0] >= (PACKET_ID_LOSSY_RANGE_START + PACKET_ID_LOSSY_RANGE_SIZE))
         return -3;
 
-    if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (tox->m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -4;
 
-    if (send_lossy_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                               m->friendlist[friendnumber].friendcon_id), data, length) == -1) {
+    if (send_lossy_cryptpacket(tox->net_crypto, toxconn_crypt_connection_id(tox->tox_conn,
+                               tox->m->friendlist[friendnumber].friendcon_id), data, length) == -1) {
         return -5;
     } else {
         return 0;
@@ -1687,9 +1725,9 @@ int send_custom_lossy_packet(const Messenger *m, int32_t friendnumber, const uin
 
 static int handle_custom_lossless_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length)
 {
-    Messenger *m = object;
+    Tox *tox = object;
 
-    if (friend_not_valid(m, friend_num))
+    if (friend_not_valid(tox->m, friend_num))
         return -1;
 
     if (packet[0] < PACKET_ID_LOSSLESS_RANGE_START)
@@ -1698,22 +1736,22 @@ static int handle_custom_lossless_packet(void *object, int friend_num, const uin
     if (packet[0] >= (PACKET_ID_LOSSLESS_RANGE_START + PACKET_ID_LOSSLESS_RANGE_SIZE))
         return -1;
 
-    if (m->lossless_packethandler)
-        m->lossless_packethandler(m, friend_num, packet, length, m->lossless_packethandler_userdata);
+    if (tox->m->lossless_packethandler)
+        tox->m->lossless_packethandler(tox, friend_num, packet, length, tox->m->lossless_packethandler_userdata);
 
     return 1;
 }
 
-void custom_lossless_packet_registerhandler(Messenger *m, void (*packet_handler_callback)(Messenger *m,
+void custom_lossless_packet_registerhandler(Tox *tox, void (*packet_handler_callback)(Tox *tox,
         uint32_t friendnumber, const uint8_t *data, size_t len, void *object), void *object)
 {
-    m->lossless_packethandler = packet_handler_callback;
-    m->lossless_packethandler_userdata = object;
+    tox->m->lossless_packethandler = packet_handler_callback;
+    tox->m->lossless_packethandler_userdata = object;
 }
 
-int send_custom_lossless_packet(const Messenger *m, int32_t friendnumber, const uint8_t *data, uint32_t length)
+int send_custom_lossless_packet(const Tox *tox, int32_t friendnumber, const uint8_t *data, uint32_t length)
 {
-    if (friend_not_valid(m, friendnumber))
+    if (friend_not_valid(tox->m, friendnumber))
         return -1;
 
     if (length == 0 || length > MAX_CRYPTO_DATA_SIZE)
@@ -1725,11 +1763,14 @@ int send_custom_lossless_packet(const Messenger *m, int32_t friendnumber, const 
     if (data[0] >= (PACKET_ID_LOSSLESS_RANGE_START + PACKET_ID_LOSSLESS_RANGE_SIZE))
         return -3;
 
-    if (m->friendlist[friendnumber].status != FRIEND_ONLINE)
+    if (tox->m->friendlist[friendnumber].status != FRIEND_ONLINE)
         return -4;
 
-    if (write_cryptpacket(m->net_crypto, tox_conn_crypt_connection_id(m->fr_c,
-                          m->friendlist[friendnumber].friendcon_id), data, length, 1) == -1) {
+    if (write_cryptpacket(tox->net_crypto,
+                          toxconn_crypt_connection_id(tox->tox_conn, tox->m->friendlist[friendnumber].friendcon_id),
+                          data,
+                          length,
+                          1) == -1) {
         return -5;
     } else {
         return 0;
@@ -1748,7 +1789,7 @@ static int friend_already_added(const uint8_t *real_pk, void *data)
 }
 
 /* Run this at startup. */
-Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
+Messenger *new_messenger(Tox* tox, Messenger_Options *options, unsigned int *error)
 {
     Messenger *m = calloc(1, sizeof(Messenger));
 
@@ -1758,72 +1799,11 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
     if ( ! m )
         return NULL;
 
-    unsigned int net_err = 0;
-
-    if (options->udp_disabled) {
-        /* this is the easiest way to completely disable UDP without changing too much code. */
-        m->net = calloc(1, sizeof(Networking_Core));
-    } else {
-        IP ip;
-        ip_init(&ip, options->ipv6enabled);
-        m->net = new_networking_ex(ip, options->port_range[0], options->port_range[1], &net_err);
-    }
-
-    if (m->net == NULL) {
-        free(m);
-
-        if (error && net_err == 1) {
-            *error = MESSENGER_ERROR_PORT;
-        }
-
-        return NULL;
-    }
-
-    m->dht = new_DHT(m->net);
-
-    if (m->dht == NULL) {
-        kill_networking(m->net);
-        free(m);
-        return NULL;
-    }
-
-    m->net_crypto = new_net_crypto(m->dht, &options->proxy_info);
-
-    if (m->net_crypto == NULL) {
-        kill_networking(m->net);
-        kill_DHT(m->dht);
-        free(m);
-        return NULL;
-    }
-
-    m->onion = new_onion(m->dht);
-    m->onion_a = new_onion_announce(m->dht);
-    m->onion_c =  new_onion_client(m->net_crypto);
-    m->fr_c = new_tox_conns(m->onion_c);
-
-    if (!(m->onion && m->onion_a && m->onion_c)) {
-        kill_tox_conns(m->fr_c);
-        kill_onion(m->onion);
-        kill_onion_announce(m->onion_a);
-        kill_onion_client(m->onion_c);
-        kill_net_crypto(m->net_crypto);
-        kill_DHT(m->dht);
-        kill_networking(m->net);
-        free(m);
-        return NULL;
-    }
-
     if (options->tcp_server_port) {
-        m->tcp_server = new_TCP_server(options->ipv6enabled, 1, &options->tcp_server_port, m->dht->self_secret_key, m->onion);
+        m->tcp_server = new_TCP_server(options->ipv6enabled, 1, &options->tcp_server_port, tox->dht->self_secret_key, tox->onion);
 
         if (m->tcp_server == NULL) {
-            kill_tox_conns(m->fr_c);
-            kill_onion(m->onion);
-            kill_onion_announce(m->onion_a);
-            kill_onion_client(m->onion_c);
-            kill_net_crypto(m->net_crypto);
-            kill_DHT(m->dht);
-            kill_networking(m->net);
+            kill_tox_conns(tox->tox_conn);
             free(m);
 
             if (error)
@@ -1834,8 +1814,8 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error)
     }
 
     m->options = *options;
-    friendreq_init(&(m->fr), m->fr_c);
-    set_nospam(&(m->fr), random_int());
+    friendreq_init(&(m->fr), tox->tox_conn);
+    set_nospam(&tox->m->fr, random_int());
     set_filter_function(&(m->fr), &friend_already_added, m);
 
     if (error)
@@ -1856,18 +1836,11 @@ void kill_messenger(Messenger *m)
         kill_TCP_server(m->tcp_server);
     }
 
-    kill_tox_conns(m->fr_c);
-    kill_onion(m->onion);
-    kill_onion_announce(m->onion_a);
-    kill_onion_client(m->onion_c);
-    kill_net_crypto(m->net_crypto);
-    kill_DHT(m->dht);
-    kill_networking(m->net);
-
     for (i = 0; i < m->numfriends; ++i) {
         clear_receipts(m, i);
     }
 
+    /* TODO free each device for each friend */
     free(m->friendlist);
     free(m);
 }
@@ -1877,12 +1850,13 @@ void kill_messenger(Messenger *m)
  *   i: friendlist index of the timed-out friend
  *   t: time
  */
-static void check_friend_request_timed_out(Messenger *m, uint32_t i, uint64_t t)
+static void check_friend_request_timed_out(Tox *tox, uint32_t i, uint64_t t)
 {
-    Friend *f = &m->friendlist[i];
+    Friend *f = &tox->m->friendlist[i];
 
     if (f->friendrequest_lastsent + f->friendrequest_timeout < t) {
-        set_friend_status(m, i, FRIEND_ADDED);
+        /* We can assume devices 0 here for now. We don't send or sync friend requests through mdev yet. */
+        set_friend_status(tox, i, FRIEND_ADDED);
         /* Double the default timeout every time if friendrequest is assumed
          * to have been sent unsuccessfully.
          */
@@ -1890,35 +1864,37 @@ static void check_friend_request_timed_out(Messenger *m, uint32_t i, uint64_t t)
     }
 }
 
-static int handle_status(void *object, int i, uint8_t status)
+static int handle_status(void *object, int friend_id, uint8_t status)
 {
-    Messenger *m = object;
+    Tox *tox = object;
 
     if (status) { /* Went online. */
-        send_online_packet(m, i);
+        set_friend_status(tox, friend_id, FRIEND_ONLINE);
+        send_online_packet(tox, friend_id);
     } else { /* Went offline. */
-        if (m->friendlist[i].status == FRIEND_ONLINE) {
-            set_friend_status(m, i, FRIEND_CONFIRMED);
+        if (tox->m->friendlist[friend_id].status == FRIEND_ONLINE) {
+            set_friend_status(tox, friend_id, FRIEND_CONFIRMED);
         }
     }
 
     return 0;
 }
 
-static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
+static int handle_packet(void *object, int friend_num, uint8_t *temp, uint16_t len)
 {
     if (len == 0)
         return -1;
 
-    Messenger *m = object;
+    Tox *tox = object;
+    Messenger *m = tox->m;
     uint8_t packet_id = temp[0];
     uint8_t *data = temp + 1;
     uint32_t data_length = len - 1;
 
-    if (m->friendlist[i].status != FRIEND_ONLINE) {
+    if (m->friendlist[friend_num].status != FRIEND_ONLINE) {
         if (packet_id == PACKET_ID_ONLINE && len == 1) {
-            set_friend_status(m, i, FRIEND_ONLINE);
-            send_online_packet(m, i);
+            set_friend_status(tox, friend_num, FRIEND_ONLINE);
+            send_online_packet(tox, friend_num);
         } else {
             return -1;
         }
@@ -1929,7 +1905,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             if (data_length != 0)
                 break;
 
-            set_friend_status(m, i, FRIEND_CONFIRMED);
+            set_friend_status(tox, friend_num, FRIEND_CONFIRMED);
             break;
         }
 
@@ -1944,10 +1920,10 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
 
             /* inform of namechange before we overwrite the old name */
             if (m->friend_namechange)
-                m->friend_namechange(m, i, data_terminated, data_length, m->friend_namechange_userdata);
+                m->friend_namechange(tox, friend_num, data_terminated, data_length, m->friend_namechange_userdata);
 
-            memcpy(m->friendlist[i].name, data_terminated, data_length);
-            m->friendlist[i].name_length = data_length;
+            memcpy(m->friendlist[friend_num].name, data_terminated, data_length);
+            m->friendlist[friend_num].name_length = data_length;
 
             break;
         }
@@ -1962,10 +1938,10 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             data_terminated[data_length] = 0;
 
             if (m->friend_statusmessagechange)
-                m->friend_statusmessagechange(m, i, data_terminated, data_length,
+                m->friend_statusmessagechange(tox, friend_num, data_terminated, data_length,
                                               m->friend_statusmessagechange_userdata);
 
-            set_friend_statusmessage(m, i, data_terminated, data_length);
+            set_friend_statusmessage(m, friend_num, data_terminated, data_length);
             break;
         }
 
@@ -1979,9 +1955,9 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
                 break;
 
             if (m->friend_userstatuschange)
-                m->friend_userstatuschange(m, i, status, m->friend_userstatuschange_userdata);
+                m->friend_userstatuschange(tox, friend_num, status, m->friend_userstatuschange_userdata);
 
-            set_friend_userstatus(m, i, status);
+            set_friend_userstatus(m, friend_num, status);
             break;
         }
 
@@ -1991,10 +1967,10 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
 
             _Bool typing = !!data[0];
 
-            set_friend_typing(m, i, typing);
+            set_friend_typing(m, friend_num, typing);
 
             if (m->friend_typingchange)
-                m->friend_typingchange(m, i, typing, m->friend_typingchange_userdata);
+                m->friend_typingchange(tox, friend_num, typing, m->friend_typingchange_userdata);
 
             break;
         }
@@ -2014,7 +1990,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             uint8_t type = packet_id - PACKET_ID_MESSAGE;
 
             if (m->friend_message)
-                (*m->friend_message)(m, i, type, message_terminated, message_length, m->friend_message_userdata);
+                (*m->friend_message)(tox, friend_num, type, message_terminated, message_length, m->friend_message_userdata);
 
             break;
         }
@@ -2024,7 +2000,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
                 break;
 
             if (m->group_invite)
-                (*m->group_invite)(m, i, data, data_length);
+                (*m->group_invite)(tox, friend_num, data, data_length);
 
             break;
         }
@@ -2052,7 +2028,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
 
             memcpy(&filesize, data + 1 + sizeof(uint32_t), sizeof(filesize));
             net_to_host((uint8_t *) &filesize, sizeof(filesize));
-            struct File_Transfers *ft = &m->friendlist[i].file_receiving[filenumber];
+            struct File_Transfers *ft = &m->friendlist[friend_num].file_receiving[filenumber];
 
             if (ft->status != FILESTATUS_NONE)
                 break;
@@ -2078,7 +2054,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             real_filenumber <<= 16;
 
             if (m->file_sendrequest)
-                (*m->file_sendrequest)(m, i, real_filenumber, file_type, filesize, filename, filename_length,
+                (*m->file_sendrequest)(tox, friend_num, real_filenumber, file_type, filesize, filename, filename_length,
                                        m->file_sendrequest_userdata);
 
             break;
@@ -2095,7 +2071,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             if (filenumber >= MAX_CONCURRENT_FILE_PIPES)
                 break;
 
-            if (handle_filecontrol(m, i, send_receive, filenumber, control_type, data + 3, data_length - 3) == -1)
+            if (handle_filecontrol(tox, friend_num, send_receive, filenumber, control_type, data + 3, data_length - 3) == -1)
                 break;
 
             break;
@@ -2110,7 +2086,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             if (filenumber >= MAX_CONCURRENT_FILE_PIPES)
                 break;
 
-            struct File_Transfers *ft = &m->friendlist[i].file_receiving[filenumber];
+            struct File_Transfers *ft = &m->friendlist[friend_num].file_receiving[filenumber];
 
             if (ft->status != FILESTATUS_TRANSFERRING)
                 break;
@@ -2134,7 +2110,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
             }
 
             if (m->file_filedata)
-                (*m->file_filedata)(m, i, real_filenumber, position, file_data, file_data_length, m->file_filedata_userdata);
+                (*m->file_filedata)(tox, friend_num, real_filenumber, position, file_data, file_data_length, m->file_filedata_userdata);
 
             ft->transferred += file_data_length;
 
@@ -2145,7 +2121,7 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
 
                 /* Full file received. */
                 if (m->file_filedata)
-                    (*m->file_filedata)(m, i, real_filenumber, position, file_data, file_data_length, m->file_filedata_userdata);
+                    (*m->file_filedata)(tox, friend_num, real_filenumber, position, file_data, file_data_length, m->file_filedata_userdata);
             }
 
             /* Data is zero, filetransfer is over. */
@@ -2161,13 +2137,13 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
                 break;
 
             if (m->msi_packet)
-                (*m->msi_packet)(m, i, data, data_length, m->msi_packet_userdata);
+                (*m->msi_packet)(tox, friend_num, data, data_length, m->msi_packet_userdata);
 
             break;
         }
 
         default: {
-            handle_custom_lossless_packet(object, i, temp, len);
+            handle_custom_lossless_packet(object, friend_num, temp, len);
             break;
         }
     }
@@ -2175,19 +2151,22 @@ static int handle_packet(void *object, int i, uint8_t *temp, uint16_t len)
     return 0;
 }
 
-void do_friends(Messenger *m)
+void do_friends(Tox *tox)
 {
+    Messenger *m = tox->m;
     uint32_t i;
     uint64_t temp_time = unix_time();
 
     for (i = 0; i < m->numfriends; ++i) {
         if (m->friendlist[i].status == FRIEND_ADDED) {
-            int fr = send_tox_conn_request_pkt(m->fr_c, m->friendlist[i].friendcon_id, m->friendlist[i].friendrequest_nospam,
-                                                m->friendlist[i].info,
-                                                m->friendlist[i].info_size);
+            int fr = send_toxconn_request_pkt(tox->tox_conn, m->friendlist[i].friendcon_id,
+                                               m->friendlist[i].friendrequest_nospam,
+                                               m->friendlist[i].info,
+                                               m->friendlist[i].info_size);
 
             if (fr >= 0) {
-                set_friend_status(m, i, FRIEND_REQUESTED);
+                /* We can assume dev 0 here and in the above request pkt as mdev doesnt' sync pending friend nospam */
+                set_friend_status(tox, i, FRIEND_REQUESTED);
                 m->friendlist[i].friendrequest_lastsent = temp_time;
             }
         }
@@ -2198,49 +2177,49 @@ void do_friends(Messenger *m)
                 /* If we didn't connect to friend after successfully sending him a friend request the request is deemed
                  * unsuccessful so we set the status back to FRIEND_ADDED and try again.
                  */
-                check_friend_request_timed_out(m, i, temp_time);
+                check_friend_request_timed_out(tox, i, temp_time);
             }
         }
 
         if (m->friendlist[i].status == FRIEND_ONLINE) { /* friend is online. */
             if (m->friendlist[i].name_sent == 0) {
-                if (m_sendname(m, i, m->name, m->name_length))
+                if (m_sendname(tox, i, m->name, m->name_length))
                     m->friendlist[i].name_sent = 1;
             }
 
             if (m->friendlist[i].statusmessage_sent == 0) {
-                if (send_statusmessage(m, i, m->statusmessage, m->statusmessage_length))
+                if (send_statusmessage(tox, i, m->statusmessage, m->statusmessage_length))
                     m->friendlist[i].statusmessage_sent = 1;
             }
 
             if (m->friendlist[i].userstatus_sent == 0) {
-                if (send_userstatus(m, i, m->userstatus))
+                if (send_userstatus(tox, i, m->userstatus))
                     m->friendlist[i].userstatus_sent = 1;
             }
 
             if (m->friendlist[i].user_istyping_sent == 0) {
-                if (send_user_istyping(m, i, m->friendlist[i].user_istyping))
+                if (send_user_istyping(tox, i, m->friendlist[i].user_istyping))
                     m->friendlist[i].user_istyping_sent = 1;
             }
 
-            check_friend_tcp_udp(m, i);
-            do_receipts(m, i);
-            do_reqchunk_filecb(m, i);
+            check_friend_tcp_udp(tox, i);
+            do_receipts(tox, i);
+            do_reqchunk_filecb(tox, i);
 
             m->friendlist[i].last_seen_time = (uint64_t) time(NULL);
         }
     }
 }
 
-static void connection_status_cb(Messenger *m)
+static void connection_status_cb(Tox *tox)
 {
-    unsigned int conn_status = onion_connection_status(m->onion_c);
+    unsigned int conn_status = onion_connection_status(tox->onion_c);
 
-    if (conn_status != m->last_connection_status) {
-        if (m->core_connection_change)
-            (*m->core_connection_change)(m, conn_status, m->core_connection_change_userdata);
+    if (conn_status != tox->m->last_connection_status) {
+        if (tox->m->core_connection_change)
+            (*tox->m->core_connection_change)(tox, conn_status, tox->m->core_connection_change_userdata);
 
-        m->last_connection_status = conn_status;
+        tox->m->last_connection_status = conn_status;
     }
 }
 
@@ -2261,8 +2240,7 @@ static char *ID2String(const uint8_t *pk)
 }
 #endif
 
-/* Minimum messenger run interval in ms
-   TODO: A/V */
+/* Minimum messenger run interval in ms */
 #define MIN_RUN_INTERVAL 50
 
 /* Return the time in milliseconds before do_messenger() should be called again
@@ -2270,9 +2248,9 @@ static char *ID2String(const uint8_t *pk)
  *
  * returns time (in ms) before the next do_messenger() needs to be run on success.
  */
-uint32_t messenger_run_interval(const Messenger *m)
+uint32_t messenger_run_interval(const Tox *tox)
 {
-    uint32_t crypto_interval = crypto_run_interval(m->net_crypto);
+    uint32_t crypto_interval = crypto_run_interval(tox->net_crypto);
 
     if (crypto_interval > MIN_RUN_INTERVAL) {
         return MIN_RUN_INTERVAL;
@@ -2282,58 +2260,53 @@ uint32_t messenger_run_interval(const Messenger *m)
 }
 
 /* The main loop that needs to be run at least 20 times per second. */
-void do_messenger(Messenger *m)
+void do_messenger(Tox *tox)
 {
     // Add the TCP relays, but only if this is the first time calling do_messenger
-    if (m->has_added_relays == 0) {
-        m->has_added_relays = 1;
+    if (tox->m->has_added_relays == 0) {
+        tox->m->has_added_relays = 1;
 
         int i;
 
         for (i = 0; i < NUM_SAVED_TCP_RELAYS; ++i) {
-            add_tcp_relay(m->net_crypto, m->loaded_relays[i].ip_port, m->loaded_relays[i].public_key);
+            add_tcp_relay(tox->net_crypto, tox->m->loaded_relays[i].ip_port, tox->m->loaded_relays[i].public_key);
         }
 
-        if (m->tcp_server) {
+        if (tox->m->tcp_server) {
             /* Add self tcp server. */
             IP_Port local_ip_port;
-            local_ip_port.port = m->options.tcp_server_port;
+            local_ip_port.port = tox->m->options.tcp_server_port;
             local_ip_port.ip.family = AF_INET;
             local_ip_port.ip.ip4.uint32 = INADDR_LOOPBACK;
-            add_tcp_relay(m->net_crypto, local_ip_port, m->tcp_server->public_key);
+            add_tcp_relay(tox->net_crypto, local_ip_port, tox->m->tcp_server->public_key);
         }
     }
 
     unix_time_update();
 
-    if (!m->options.udp_disabled) {
-        networking_poll(m->net);
-        do_DHT(m->dht);
+    if (!tox->m->options.udp_disabled) {
+        networking_poll(tox->net);
+        do_DHT(tox->dht);
     }
 
-    if (m->tcp_server) {
-        do_TCP_server(m->tcp_server);
+    if (tox->m->tcp_server) {
+        do_TCP_server(tox->m->tcp_server);
     }
 
-    do_net_crypto(m->net_crypto);
-    do_onion_client(m->onion_c);
-    do_tox_connections(m->fr_c);
-    do_friends(m);
-    connection_status_cb(m);
+    do_net_crypto(tox->net_crypto);
+    do_onion_client(tox->onion_c);
+    do_friends(tox);
+    connection_status_cb(tox);
 
 #ifdef TOX_LOGGER
 
     if (unix_time() > lastdump + DUMPING_CLIENTS_FRIENDS_EVERY_N_SECONDS) {
 
-#ifdef ENABLE_ASSOC_DHT
-        Assoc_status(m->dht->assoc);
-#endif
-
         lastdump = unix_time();
         uint32_t client, last_pinged;
 
         for (client = 0; client < LCLIENT_LIST; client++) {
-            Client_data *cptr = &m->dht->close_clientlist[client];
+            Client_data *cptr = &tox->dht->close_clientlist[client];
             IPPTsPng *assoc = NULL;
             uint32_t a;
 
@@ -2354,7 +2327,7 @@ void do_messenger(Messenger *m)
         uint32_t friend, dhtfriend;
 
         /* dht contains additional "friends" (requests) */
-        uint32_t num_dhtfriends = m->dht->num_friends;
+        uint32_t num_dhtfriends = tox->dht->num_friends;
         int32_t m2dht[num_dhtfriends];
         int32_t dht2m[num_dhtfriends];
 
@@ -2365,8 +2338,8 @@ void do_messenger(Messenger *m)
             if (friend >= m->numfriends)
                 continue;
 
-            for (dhtfriend = 0; dhtfriend < m->dht->num_friends; dhtfriend++)
-                if (id_equal(m->friendlist[friend].real_pk, m->dht->friends_list[dhtfriend].public_key)) {
+            for (dhtfriend = 0; dhtfriend < tox->dht->num_friends; dhtfriend++)
+                if (id_equal(m->friendlist[friend].real_pk, tox->dht->friends_list[dhtfriend].public_key)) {
                     m2dht[friend] = dhtfriend;
                     break;
                 }
@@ -2376,8 +2349,8 @@ void do_messenger(Messenger *m)
             if (m2dht[friend] >= 0)
                 dht2m[m2dht[friend]] = friend;
 
-        if (m->numfriends != m->dht->num_friends) {
-            LOGGER_TRACE("Friend num in DHT %u != friend num in msger %u\n", m->dht->num_friends, m->numfriends);
+        if (m->numfriends != tox->dht->num_friends) {
+            LOGGER_TRACE("Friend num in DHT %u != friend num in msger %u\n", tox->dht->num_friends, m->numfriends);
         }
 
         Friend *msgfptr;
@@ -2389,7 +2362,7 @@ void do_messenger(Messenger *m)
             else
                 msgfptr = NULL;
 
-            dhtfptr = &m->dht->friends_list[friend];
+            dhtfptr = &tox->dht->friends_list[friend];
 
             if (msgfptr) {
                 LOGGER_TRACE("F[%2u:%2u] <%s> %s",
@@ -2423,7 +2396,6 @@ void do_messenger(Messenger *m)
 #endif /* TOX_LOGGER */
 }
 
-/* new messenger format for load/save, more robust and forward compatible */
 
 #define MESSENGER_STATE_COOKIE_GLOBAL 0x15ed1b1f
 
@@ -2440,6 +2412,7 @@ void do_messenger(Messenger *m)
 
 #define SAVED_FRIEND_REQUEST_SIZE 1024
 #define NUM_SAVED_PATH_NODES 8
+/* On-disk friend format for pre multi-device toxcore versions */
 struct SAVED_FRIEND {
     uint8_t status;
     uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
@@ -2453,6 +2426,7 @@ struct SAVED_FRIEND {
     uint32_t friendrequest_nospam;
     uint64_t last_seen_time;
 };
+
 
 static uint32_t saved_friendslist_size(const Messenger *m)
 {
@@ -2501,8 +2475,10 @@ static uint32_t friends_list_save(const Messenger *m, uint8_t *data)
     return num * sizeof(struct SAVED_FRIEND);
 }
 
-static int friends_list_load(Messenger *m, const uint8_t *data, uint32_t length)
+static int friends_list_load(Tox *tox, const uint8_t *data, uint32_t length)
 {
+    Messenger *m = tox->m;
+
     if (length % sizeof(struct SAVED_FRIEND) != 0) {
         return -1;
     }
@@ -2515,7 +2491,7 @@ static int friends_list_load(Messenger *m, const uint8_t *data, uint32_t length)
         memcpy(&temp, data + i * sizeof(struct SAVED_FRIEND), sizeof(struct SAVED_FRIEND));
 
         if (temp.status >= 3) {
-            int fnum = m_addfriend_norequest(m, temp.real_pk);
+            int fnum = m_addfriend_norequest(tox, temp.real_pk);
 
             if (fnum < 0)
                 continue;
@@ -2534,7 +2510,7 @@ static int friends_list_load(Messenger *m, const uint8_t *data, uint32_t length)
             memcpy(address + crypto_box_PUBLICKEYBYTES, &(temp.friendrequest_nospam), sizeof(uint32_t));
             uint16_t checksum = address_checksum(address, FRIEND_ADDRESS_SIZE - sizeof(checksum));
             memcpy(address + crypto_box_PUBLICKEYBYTES + sizeof(uint32_t), &checksum, sizeof(checksum));
-            m_addfriend(m, address, temp.info, ntohs(temp.info_size));
+            m_addfriend(tox, address, temp.info, ntohs(temp.info_size));
         }
     }
 
@@ -2542,12 +2518,14 @@ static int friends_list_load(Messenger *m, const uint8_t *data, uint32_t length)
 }
 
 /*  return size of the messenger data (for saving) */
-uint32_t messenger_size(const Messenger *m)
+uint32_t messenger_size(const Tox *tox)
 {
+    Messenger *m = tox->m;
+
     uint32_t size32 = sizeof(uint32_t), sizesubhead = size32 * 2;
     return   size32 * 2                                      // global cookie
              + sizesubhead + sizeof(uint32_t) + crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES
-             + sizesubhead + DHT_size(m->dht)                  // DHT
+             + sizesubhead + DHT_size(tox->dht)                  // DHT
              + sizesubhead + saved_friendslist_size(m)         // Friendlist itself.
              + sizesubhead + m->name_length                    // Own nickname.
              + sizesubhead + m->statusmessage_length           // status message
@@ -2567,9 +2545,11 @@ static uint8_t *z_state_save_subheader(uint8_t *data, uint32_t len, uint16_t typ
 }
 
 /* Save the messenger in data of size Messenger_size(). */
-void messenger_save(const Messenger *m, uint8_t *data)
+void messenger_save(const Tox *tox, uint8_t *data)
 {
-    memset(data, 0, messenger_size(m));
+    Messenger *m = tox->m;
+
+    memset(data, 0, messenger_size(tox));
 
     uint32_t len;
     uint16_t type;
@@ -2587,7 +2567,7 @@ void messenger_save(const Messenger *m, uint8_t *data)
     type = MESSENGER_STATE_TYPE_NOSPAMKEYS;
     data = z_state_save_subheader(data, len, type);
     *(uint32_t *)data = get_nospam(&(m->fr));
-    save_keys(m->net_crypto, data + size32);
+    save_keys(tox->net_crypto, data + size32);
     data += len;
 
     len = saved_friendslist_size(m);
@@ -2614,17 +2594,17 @@ void messenger_save(const Messenger *m, uint8_t *data)
     *data = m->userstatus;
     data += len;
 
-    len = DHT_size(m->dht);
+    len = DHT_size(tox->dht);
     type = MESSENGER_STATE_TYPE_DHT;
     data = z_state_save_subheader(data, len, type);
-    DHT_save(m->dht, data);
+    DHT_save(tox->dht, data);
     data += len;
 
     Node_format relays[NUM_SAVED_TCP_RELAYS];
     type = MESSENGER_STATE_TYPE_TCP_RELAY;
     uint8_t *temp_data = data;
     data = z_state_save_subheader(temp_data, 0, type);
-    unsigned int num = copy_connected_tcp_relays(m->net_crypto, relays, NUM_SAVED_TCP_RELAYS);
+    unsigned int num = copy_connected_tcp_relays(tox->net_crypto, relays, NUM_SAVED_TCP_RELAYS);
     int l = pack_nodes(data, NUM_SAVED_TCP_RELAYS * packed_node_size(TCP_INET6), relays, num);
 
     if (l > 0) {
@@ -2638,7 +2618,7 @@ void messenger_save(const Messenger *m, uint8_t *data)
     temp_data = data;
     data = z_state_save_subheader(data, 0, type);
     memset(nodes, 0, sizeof(nodes));
-    num = onion_backup_nodes(m->onion_c, nodes, NUM_SAVED_PATH_NODES);
+    num = onion_backup_nodes(tox->onion_c, nodes, NUM_SAVED_PATH_NODES);
     l = pack_nodes(data, NUM_SAVED_PATH_NODES * packed_node_size(TCP_INET6), nodes, num);
 
     if (l > 0) {
@@ -2652,15 +2632,16 @@ void messenger_save(const Messenger *m, uint8_t *data)
 
 static int messenger_load_state_callback(void *outer, const uint8_t *data, uint32_t length, uint16_t type)
 {
-    Messenger *m = outer;
+    Tox *tox = outer;
+    Messenger *m = tox->m;
 
     switch (type) {
         case MESSENGER_STATE_TYPE_NOSPAMKEYS:
             if (length == crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES + sizeof(uint32_t)) {
                 set_nospam(&(m->fr), *(uint32_t *)data);
-                load_secret_key(m->net_crypto, (&data[sizeof(uint32_t)]) + crypto_box_PUBLICKEYBYTES);
+                load_secret_key(tox->net_crypto, (&data[sizeof(uint32_t)]) + crypto_box_PUBLICKEYBYTES);
 
-                if (public_key_cmp((&data[sizeof(uint32_t)]), m->net_crypto->self_public_key) != 0) {
+                if (memcmp((&data[sizeof(uint32_t)]), tox->net_crypto->self_public_key, crypto_box_PUBLICKEYBYTES) != 0) {
                     return -1;
                 }
             } else
@@ -2669,11 +2650,11 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             break;
 
         case MESSENGER_STATE_TYPE_DHT:
-            DHT_load(m->dht, data, length);
+            DHT_load(tox->dht, data, length);
             break;
 
         case MESSENGER_STATE_TYPE_FRIENDS:
-            friends_list_load(m, data, length);
+            friends_list_load(tox, data, length);
             break;
 
         case MESSENGER_STATE_TYPE_NAME:
@@ -2685,14 +2666,14 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
 
         case MESSENGER_STATE_TYPE_STATUSMESSAGE:
             if ((length > 0) && (length < MAX_STATUSMESSAGE_LENGTH)) {
-                m_set_statusmessage(m, data, length);
+                m_set_statusmessage(tox, data, length);
             }
 
             break;
 
         case MESSENGER_STATE_TYPE_STATUS:
             if (length == 1) {
-                m_set_userstatus(m, *data);
+                m_set_userstatus(tox, *data);
             }
 
             break;
@@ -2718,7 +2699,7 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             int i, num = unpack_nodes(nodes, NUM_SAVED_PATH_NODES, 0, data, length, 0);
 
             for (i = 0; i < num; ++i) {
-                onion_add_bs_path_node(m->onion_c, nodes[i].ip_port, nodes[i].public_key);
+                onion_add_bs_path_node(tox->onion_c, nodes[i].ip_port, nodes[i].public_key);
             }
 
             break;

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -218,7 +218,7 @@ struct Messenger {
     Onion_Announce *onion_a;
     Onion_Client *onion_c;
 
-    Friend_Connections *fr_c;
+    Tox_Connections *fr_c;
 
     TCP_Server *tcp_server;
     Friend_Requests fr;

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -27,7 +27,7 @@
 #define MESSENGER_H
 
 #include "friend_requests.h"
-#include "friend_connection.h"
+#include "tox_connection.h"
 
 #define MAX_NAME_LENGTH 128
 /* TODO: this must depend on other variable. */

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -215,7 +215,7 @@ int send_packet_tcp_connection(TCP_Connections *tcp_c, int connections_number, c
 
     _Bool limit_reached = 0;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         uint32_t tcp_con_num = con_to->connections[i].tcp_connection;
         uint8_t status = con_to->connections[i].status;
         uint8_t connection_id = con_to->connections[i].connection_id;
@@ -246,7 +246,7 @@ int send_packet_tcp_connection(TCP_Connections *tcp_c, int connections_number, c
         ret = 0;
 
         /* Send oob packets to all relays tied to the connection. */
-        for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+        for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
             uint32_t tcp_con_num = con_to->connections[i].tcp_connection;
             uint8_t status = con_to->connections[i].status;
 
@@ -461,7 +461,7 @@ int kill_tcp_connection_to(TCP_Connections *tcp_c, int connections_number)
 
     unsigned int i;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         if (con_to->connections[i].tcp_connection) {
             unsigned int tcp_connections_number = con_to->connections[i].tcp_connection - 1;
             TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
@@ -510,7 +510,7 @@ int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number,
 
         unsigned int i;
 
-        for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+        for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
             if (con_to->connections[i].tcp_connection) {
                 unsigned int tcp_connections_number = con_to->connections[i].tcp_connection - 1;
                 TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
@@ -533,7 +533,7 @@ int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number,
 
         unsigned int i;
 
-        for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+        for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
             if (con_to->connections[i].tcp_connection) {
                 unsigned int tcp_connections_number = con_to->connections[i].tcp_connection - 1;
                 TCP_con *tcp_con = get_tcp_connection(tcp_c, tcp_connections_number);
@@ -556,7 +556,7 @@ static _Bool tcp_connection_in_conn(TCP_Connection_to *con_to, unsigned int tcp_
 {
     unsigned int i;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         if (con_to->connections[i].tcp_connection == (tcp_connections_number + 1)) {
             return 1;
         }
@@ -575,7 +575,7 @@ static int add_tcp_connection_to_conn(TCP_Connection_to *con_to, unsigned int tc
     if (tcp_connection_in_conn(con_to, tcp_connections_number))
         return -1;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         if (con_to->connections[i].tcp_connection == 0) {
             con_to->connections[i].tcp_connection = tcp_connections_number + 1;
             con_to->connections[i].status = TCP_CONNECTIONS_STATUS_NONE;
@@ -594,7 +594,7 @@ static int rm_tcp_connection_from_conn(TCP_Connection_to *con_to, unsigned int t
 {
     unsigned int i;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         if (con_to->connections[i].tcp_connection == (tcp_connections_number + 1)) {
             con_to->connections[i].tcp_connection = 0;
             con_to->connections[i].status = TCP_CONNECTIONS_STATUS_NONE;
@@ -613,7 +613,7 @@ static unsigned int online_tcp_connection_from_conn(TCP_Connection_to *con_to)
 {
     unsigned int i, count = 0;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         if (con_to->connections[i].tcp_connection) {
             if (con_to->connections[i].status == TCP_CONNECTIONS_STATUS_ONLINE) {
                 ++count;
@@ -632,7 +632,7 @@ static int set_tcp_connection_status(TCP_Connection_to *con_to, unsigned int tcp
 {
     unsigned int i;
 
-    for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
+    for (i = 0; i < MAX_TCP_CONNECTIONS_FRIENDS; ++i) {
         if (con_to->connections[i].tcp_connection == (tcp_connections_number + 1)) {
 
             if (con_to->connections[i].status == status) {
@@ -1108,7 +1108,7 @@ int add_tcp_relay_connection(TCP_Connections *tcp_c, int connections_number, IP_
     if (tcp_connections_number != -1) {
         return add_tcp_number_relay_connection(tcp_c, connections_number, tcp_connections_number);
     } else {
-        if (online_tcp_connection_from_conn(con_to) >= RECOMMENDED_FRIEND_TCP_CONNECTIONS) {
+        if (online_tcp_connection_from_conn(con_to) >= RECOMMENDED_TCP_CONNECTIONS_FRIENDS) {
             return -1;
         }
 
@@ -1329,10 +1329,10 @@ static void kill_nonused_tcp(TCP_Connections *tcp_c)
         }
     }
 
-    if (num_online <= RECOMMENDED_FRIEND_TCP_CONNECTIONS) {
+    if (num_online <= RECOMMENDED_TCP_CONNECTIONS_FRIENDS) {
         return;
     } else {
-        unsigned int n = num_online - RECOMMENDED_FRIEND_TCP_CONNECTIONS;
+        unsigned int n = num_online - RECOMMENDED_TCP_CONNECTIONS_FRIENDS;
 
         if (n < num_kill)
             num_kill = n;

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -39,17 +39,17 @@
 #define TCP_CONNECTIONS_STATUS_REGISTERED 1
 #define TCP_CONNECTIONS_STATUS_ONLINE 2
 
-#define MAX_FRIEND_TCP_CONNECTIONS 6
+#define MAX_TCP_CONNECTIONS_FRIENDS 6
 
 /* Time until connection to friend gets killed (if it doesn't get locked withing that time) */
 #define TCP_CONNECTION_ANNOUNCE_TIMEOUT (TCP_CONNECTION_TIMEOUT)
 
 /* The amount of recommended connections for each friend
-   NOTE: Must be at most (MAX_FRIEND_TCP_CONNECTIONS / 2) */
-#define RECOMMENDED_FRIEND_TCP_CONNECTIONS (MAX_FRIEND_TCP_CONNECTIONS / 2)
+   NOTE: Must be at most (MAX_TCP_CONNECTIONS_FRIENDS / 2) */
+#define RECOMMENDED_TCP_CONNECTIONS_FRIENDS (MAX_TCP_CONNECTIONS_FRIENDS / 2)
 
 /* Number of TCP connections used for onion purposes. */
-#define NUM_ONION_TCP_CONNECTIONS RECOMMENDED_FRIEND_TCP_CONNECTIONS
+#define NUM_ONION_TCP_CONNECTIONS RECOMMENDED_TCP_CONNECTIONS_FRIENDS
 
 typedef struct {
     uint8_t status;
@@ -59,7 +59,7 @@ typedef struct {
         uint32_t tcp_connection;
         unsigned int status;
         unsigned int connection_id;
-    } connections[MAX_FRIEND_TCP_CONNECTIONS];
+    } connections[MAX_TCP_CONNECTIONS_FRIENDS];
 
     int id; /* id used in callbacks. */
 } TCP_Connection_to;

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -1,8 +1,8 @@
-/* friend_connection.c
+/* tox_connection.c
  *
- * Connection to friends.
+ * Connection to tox instances.
  *
- *  Copyright (C) 2014 Tox project All Rights Reserved.
+ *  Copyright (C) 2016 Tox project All Rights Reserved.
  *
  *  This file is part of Tox.
  *
@@ -28,117 +28,117 @@
 #include "friend_connection.h"
 #include "util.h"
 
-/* return 1 if the friendcon_id is not valid.
- * return 0 if the friendcon_id is valid.
+/* return 1 if the toxconn_id is not valid.
+ * return 0 if the toxconn_id is valid.
  */
-static uint8_t friendconn_id_not_valid(const Friend_Connections *fr_c, int friendcon_id)
+static uint8_t toxconn_id_not_valid(const Tox_Connections *tox_conns, int toxconn_id)
 {
-    if ((unsigned int)friendcon_id >= fr_c->num_cons)
+    if ((unsigned int)toxconn_id >= tox_conns->num_cons)
         return 1;
 
-    if (fr_c->conns == NULL)
+    if (tox_conns->conns == NULL)
         return 1;
 
-    if (fr_c->conns[friendcon_id].status == FRIENDCONN_STATUS_NONE)
+    if (tox_conns->conns[toxconn_id].status == TOXCONN_STATUS_NONE)
         return 1;
 
     return 0;
 }
 
 
-/* Set the size of the friend connections list to num.
+/* Set the size of the tox connections list to num.
  *
  *  return -1 if realloc fails.
  *  return 0 if it succeeds.
  */
-static int realloc_friendconns(Friend_Connections *fr_c, uint32_t num)
+static int realloc_toxconns(Tox_Connections *tox_conns, uint32_t num)
 {
     if (num == 0) {
-        free(fr_c->conns);
-        fr_c->conns = NULL;
+        free(tox_conns->conns);
+        tox_conns->conns = NULL;
         return 0;
     }
 
-    Friend_Conn *newgroup_cons = realloc(fr_c->conns, num * sizeof(Friend_Conn));
+    Tox_Conn *newgroup_cons = realloc(tox_conns->conns, num * sizeof(Tox_Conn));
 
     if (newgroup_cons == NULL)
         return -1;
 
-    fr_c->conns = newgroup_cons;
+    tox_conns->conns = newgroup_cons;
     return 0;
 }
 
-/* Create a new empty friend connection.
+/* Create a new empty tox connection.
  *
  * return -1 on failure.
- * return friendcon_id on success.
+ * return toxconn_id on success.
  */
-static int create_friend_conn(Friend_Connections *fr_c)
+static int create_toxconn(Tox_Connections *tox_conns)
 {
     uint32_t i;
 
-    for (i = 0; i < fr_c->num_cons; ++i) {
-        if (fr_c->conns[i].status == FRIENDCONN_STATUS_NONE)
+    for (i = 0; i < tox_conns->num_cons; ++i) {
+        if (tox_conns->conns[i].status == TOXCONN_STATUS_NONE)
             return i;
     }
 
     int id = -1;
 
-    if (realloc_friendconns(fr_c, fr_c->num_cons + 1) == 0) {
-        id = fr_c->num_cons;
-        ++fr_c->num_cons;
-        memset(&(fr_c->conns[id]), 0, sizeof(Friend_Conn));
+    if (realloc_toxconns(tox_conns, tox_conns->num_cons + 1) == 0) {
+        id = tox_conns->num_cons;
+        ++tox_conns->num_cons;
+        memset(&(tox_conns->conns[id]), 0, sizeof(Tox_Conn));
     }
 
     return id;
 }
 
-/* Wipe a friend connection.
+/* Wipe a single tox connection.
  *
  * return -1 on failure.
  * return 0 on success.
  */
-static int wipe_friend_conn(Friend_Connections *fr_c, int friendcon_id)
+static int wipe_tox_conn(Tox_Connections *tox_conns, int toxconn_id)
 {
-    if (friendconn_id_not_valid(fr_c, friendcon_id))
+    if (toxconn_id_not_valid(tox_conns, toxconn_id))
         return -1;
 
     uint32_t i;
-    memset(&(fr_c->conns[friendcon_id]), 0 , sizeof(Friend_Conn));
+    memset(&(tox_conns->conns[toxconn_id]), 0 , sizeof(Tox_Conn));
 
-    for (i = fr_c->num_cons; i != 0; --i) {
-        if (fr_c->conns[i - 1].status != FRIENDCONN_STATUS_NONE)
+    for (i = tox_conns->num_cons; i != 0; --i) {
+        if (tox_conns->conns[i - 1].status != TOXCONN_STATUS_NONE)
             break;
     }
 
-    if (fr_c->num_cons != i) {
-        fr_c->num_cons = i;
-        realloc_friendconns(fr_c, fr_c->num_cons);
+    if (tox_conns->num_cons != i) {
+        tox_conns->num_cons = i;
+        realloc_toxconns(tox_conns, tox_conns->num_cons);
     }
 
     return 0;
 }
 
-static Friend_Conn *get_conn(const Friend_Connections *fr_c, int friendcon_id)
+static Tox_Conn *get_conn(const Tox_Connections *tox_conns, int toxconn_id)
 {
-    if (friendconn_id_not_valid(fr_c, friendcon_id))
+    if (toxconn_id_not_valid(tox_conns, toxconn_id))
         return 0;
 
-    return &fr_c->conns[friendcon_id];
+    return &tox_conns->conns[toxconn_id];
 }
 
-/* return friendcon_id corresponding to the real public key on success.
+/* return toxconn_id corresponding to the real public key on success.
  * return -1 on failure.
  */
-int getfriend_conn_id_pk(Friend_Connections *fr_c, const uint8_t *real_pk)
+int gettox_conn_id_pk(Tox_Connections *tox_conns, const uint8_t *real_pk)
 {
     uint32_t i;
 
-    for (i = 0; i < fr_c->num_cons; ++i) {
-        Friend_Conn *friend_con = get_conn(fr_c, i);
+    for (i = 0; i < tox_conns->num_cons; ++i) {
+        Tox_Conn *tox_con = get_conn(tox_conns, i);
 
-        if (friend_con) {
-            if (public_key_cmp(friend_con->real_public_key, real_pk) == 0)
+        if (tox_con) {
+            if (public_key_cmp(tox_con->real_public_key, real_pk) == 0)
                 return i;
         }
     }
@@ -146,86 +146,86 @@ int getfriend_conn_id_pk(Friend_Connections *fr_c, const uint8_t *real_pk)
     return -1;
 }
 
-/* Add a TCP relay associated to the friend.
+/* Add a TCP relay associated to the connection.
  *
  * return -1 on failure.
  * return 0 on success.
  */
-int friend_add_tcp_relay(Friend_Connections *fr_c, int friendcon_id, IP_Port ip_port, const uint8_t *public_key)
+int toxconn_add_tcp_relay(Tox_Connections *tox_conns, int toxconn_id, IP_Port ip_port, const uint8_t *public_key)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     /* Local ip and same pk means that they are hosting a TCP relay. */
-    if (Local_ip(ip_port.ip) && public_key_cmp(friend_con->dht_temp_pk, public_key) == 0) {
-        if (friend_con->dht_ip_port.ip.family != 0) {
-            ip_port.ip = friend_con->dht_ip_port.ip;
+    if (Local_ip(ip_port.ip) && public_key_cmp(tox_con->dht_temp_pk, public_key) == 0) {
+        if (tox_con->dht_ip_port.ip.family != 0) {
+            ip_port.ip = tox_con->dht_ip_port.ip;
         } else {
-            friend_con->hosting_tcp_relay = 0;
+            tox_con->hosting_tcp_relay = 0;
         }
     }
 
     unsigned int i;
 
-    uint16_t index = friend_con->tcp_relay_counter % FRIEND_MAX_STORED_TCP_RELAYS;
+    uint16_t index = tox_con->tcp_relay_counter % TOXCONN_MAX_STORED_TCP_RELAYS;
 
-    for (i = 0; i < FRIEND_MAX_STORED_TCP_RELAYS; ++i) {
-        if (friend_con->tcp_relays[i].ip_port.ip.family != 0
-                && public_key_cmp(friend_con->tcp_relays[i].public_key, public_key) == 0) {
-            memset(&friend_con->tcp_relays[i], 0, sizeof(Node_format));
+    for (i = 0; i < TOXCONN_MAX_STORED_TCP_RELAYS; ++i) {
+        if (tox_con->tcp_relays[i].ip_port.ip.family != 0
+                && public_key_cmp(tox_con->tcp_relays[i].public_key, public_key) == 0) {
+            memset(&tox_con->tcp_relays[i], 0, sizeof(Node_format));
         }
     }
 
-    friend_con->tcp_relays[index].ip_port = ip_port;
-    memcpy(friend_con->tcp_relays[index].public_key, public_key, crypto_box_PUBLICKEYBYTES);
-    ++friend_con->tcp_relay_counter;
+    tox_con->tcp_relays[index].ip_port = ip_port;
+    memcpy(tox_con->tcp_relays[index].public_key, public_key, crypto_box_PUBLICKEYBYTES);
+    ++tox_con->tcp_relay_counter;
 
-    return add_tcp_relay_peer(fr_c->net_crypto, friend_con->crypt_connection_id, ip_port, public_key);
+    return add_tcp_relay_peer(tox_conns->net_crypto, tox_con->crypt_connection_id, ip_port, public_key);
 }
 
-/* Connect to number saved relays for friend. */
-static void connect_to_saved_tcp_relays(Friend_Connections *fr_c, int friendcon_id, unsigned int number)
+/* Connect to number saved relays for connection. */
+static void connect_to_saved_tcp_relays(Tox_Connections *tox_conns, int toxconn_id, unsigned int number)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return;
 
     unsigned int i;
 
-    for (i = 0; (i < FRIEND_MAX_STORED_TCP_RELAYS) && (number != 0); ++i) {
-        uint16_t index = (friend_con->tcp_relay_counter - (i + 1)) % FRIEND_MAX_STORED_TCP_RELAYS;
+    for (i = 0; (i < TOXCONN_MAX_STORED_TCP_RELAYS) && (number != 0); ++i) {
+        uint16_t index = (tox_con->tcp_relay_counter - (i + 1)) % TOXCONN_MAX_STORED_TCP_RELAYS;
 
-        if (friend_con->tcp_relays[index].ip_port.ip.family) {
-            if (add_tcp_relay_peer(fr_c->net_crypto, friend_con->crypt_connection_id, friend_con->tcp_relays[index].ip_port,
-                                   friend_con->tcp_relays[index].public_key) == 0) {
+        if (tox_con->tcp_relays[index].ip_port.ip.family) {
+            if (add_tcp_relay_peer(tox_conns->net_crypto, tox_con->crypt_connection_id, tox_con->tcp_relays[index].ip_port,
+                                   tox_con->tcp_relays[index].public_key) == 0) {
                 --number;
             }
         }
     }
 }
 
-static unsigned int send_relays(Friend_Connections *fr_c, int friendcon_id)
+static unsigned int send_relays(Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return 0;
 
     Node_format nodes[MAX_SHARED_RELAYS];
     uint8_t data[1024];
     int n, length;
 
-    n = copy_connected_tcp_relays(fr_c->net_crypto, nodes, MAX_SHARED_RELAYS);
+    n = copy_connected_tcp_relays(tox_conns->net_crypto, nodes, MAX_SHARED_RELAYS);
 
     int i;
 
     for (i = 0; i < n; ++i) {
         /* Associated the relays being sent with this connection.
            On receiving the peer will do the same which will establish the connection. */
-        friend_add_tcp_relay(fr_c, friendcon_id, nodes[i].ip_port, nodes[i].public_key);
+        toxconn_add_tcp_relay(tox_conns, toxconn_id, nodes[i].ip_port, nodes[i].public_key);
     }
 
     length = pack_nodes(data + 1, sizeof(data) - 1, nodes, n);
@@ -236,8 +236,8 @@ static unsigned int send_relays(Friend_Connections *fr_c, int friendcon_id)
     data[0] = PACKET_ID_SHARE_RELAYS;
     ++length;
 
-    if (write_cryptpacket(fr_c->net_crypto, friend_con->crypt_connection_id, data, length, 0) != -1) {
-        friend_con->share_relays_lastsent = unix_time();
+    if (write_cryptpacket(tox_conns->net_crypto, tox_con->crypt_connection_id, data, length, 0) != -1) {
+        tox_con->share_relays_lastsent = unix_time();
         return 1;
     }
 
@@ -247,100 +247,100 @@ static unsigned int send_relays(Friend_Connections *fr_c, int friendcon_id)
 /* callback for recv TCP relay nodes. */
 static int tcp_relay_node_callback(void *object, uint32_t number, IP_Port ip_port, const uint8_t *public_key)
 {
-    Friend_Connections *fr_c = object;
-    Friend_Conn *friend_con = get_conn(fr_c, number);
+    Tox_Connections *tox_conns = object;
+    Tox_Conn *tox_con = get_conn(tox_conns, number);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
-    if (friend_con->crypt_connection_id != -1) {
-        return friend_add_tcp_relay(fr_c, number, ip_port, public_key);
+    if (tox_con->crypt_connection_id != -1) {
+        return toxconn_add_tcp_relay(tox_conns, number, ip_port, public_key);
     } else {
-        return add_tcp_relay(fr_c->net_crypto, ip_port, public_key);
+        return add_tcp_relay(tox_conns->net_crypto, ip_port, public_key);
     }
 }
 
-static int friend_new_connection(Friend_Connections *fr_c, int friendcon_id);
+static int toxconn_new_connection(Tox_Connections *tox_conns, int toxconn_id);
 /* Callback for DHT ip_port changes. */
 static void dht_ip_callback(void *object, int32_t number, IP_Port ip_port)
 {
-    Friend_Connections *fr_c = object;
-    Friend_Conn *friend_con = get_conn(fr_c, number);
+    Tox_Connections *tox_conns = object;
+    Tox_Conn *tox_con = get_conn(tox_conns, number);
 
-    if (!friend_con)
+    if (!tox_con)
         return;
 
-    if (friend_con->crypt_connection_id == -1) {
-        friend_new_connection(fr_c, number);
+    if (tox_con->crypt_connection_id == -1) {
+        toxconn_new_connection(tox_conns, number);
     }
 
-    set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, ip_port, 1);
-    friend_con->dht_ip_port = ip_port;
-    friend_con->dht_ip_port_lastrecv = unix_time();
+    set_direct_ip_port(tox_conns->net_crypto, tox_con->crypt_connection_id, ip_port, 1);
+    tox_con->dht_ip_port = ip_port;
+    tox_con->dht_ip_port_lastrecv = unix_time();
 
-    if (friend_con->hosting_tcp_relay) {
-        friend_add_tcp_relay(fr_c, number, ip_port, friend_con->dht_temp_pk);
-        friend_con->hosting_tcp_relay = 0;
+    if (tox_con->hosting_tcp_relay) {
+        toxconn_add_tcp_relay(tox_conns, number, ip_port, tox_con->dht_temp_pk);
+        tox_con->hosting_tcp_relay = 0;
     }
 }
 
-static void change_dht_pk(Friend_Connections *fr_c, int friendcon_id, const uint8_t *dht_public_key)
+static void change_dht_pk(Tox_Connections *tox_conns, int toxconn_id, const uint8_t *dht_public_key)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return;
 
-    friend_con->dht_pk_lastrecv = unix_time();
+    tox_con->dht_pk_lastrecv = unix_time();
 
-    if (friend_con->dht_lock) {
-        if (DHT_delfriend(fr_c->dht, friend_con->dht_temp_pk, friend_con->dht_lock) != 0) {
+    if (tox_con->dht_lock) {
+        if (DHT_delfriend(tox_conns->dht, tox_con->dht_temp_pk, tox_con->dht_lock) != 0) {
             printf("a. Could not delete dht peer. Please report this.\n");
             return;
         }
 
-        friend_con->dht_lock = 0;
+        tox_con->dht_lock = 0;
     }
 
-    DHT_addfriend(fr_c->dht, dht_public_key, dht_ip_callback, fr_c, friendcon_id, &friend_con->dht_lock);
-    memcpy(friend_con->dht_temp_pk, dht_public_key, crypto_box_PUBLICKEYBYTES);
+    DHT_addfriend(tox_conns->dht, dht_public_key, dht_ip_callback, tox_conns, toxconn_id, &tox_con->dht_lock);
+    memcpy(tox_con->dht_temp_pk, dht_public_key, crypto_box_PUBLICKEYBYTES);
 }
 
 static int handle_status(void *object, int number, uint8_t status)
 {
-    Friend_Connections *fr_c = object;
-    Friend_Conn *friend_con = get_conn(fr_c, number);
+    Tox_Connections *tox_conns = object;
+    Tox_Conn *tox_con = get_conn(tox_conns, number);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     _Bool call_cb = 0;
 
     if (status) {  /* Went online. */
         call_cb = 1;
-        friend_con->status = FRIENDCONN_STATUS_CONNECTED;
-        friend_con->ping_lastrecv = unix_time();
-        friend_con->share_relays_lastsent = 0;
-        onion_set_friend_online(fr_c->onion_c, friend_con->onion_friendnum, status);
+        tox_con->status = TOXCONN_STATUS_CONNECTED;
+        tox_con->ping_lastrecv = unix_time();
+        tox_con->share_relays_lastsent = 0;
+        onion_set_friend_online(tox_conns->onion_c, tox_con->onion_friendnum, status);
     } else {  /* Went offline. */
-        if (friend_con->status != FRIENDCONN_STATUS_CONNECTING) {
+        if (tox_con->status != TOXCONN_STATUS_CONNECTING) {
             call_cb = 1;
-            friend_con->dht_pk_lastrecv = unix_time();
-            onion_set_friend_online(fr_c->onion_c, friend_con->onion_friendnum, status);
+            tox_con->dht_pk_lastrecv = unix_time();
+            onion_set_friend_online(tox_conns->onion_c, tox_con->onion_friendnum, status);
         }
 
-        friend_con->status = FRIENDCONN_STATUS_CONNECTING;
-        friend_con->crypt_connection_id = -1;
-        friend_con->hosting_tcp_relay = 0;
+        tox_con->status = TOXCONN_STATUS_CONNECTING;
+        tox_con->crypt_connection_id = -1;
+        tox_con->hosting_tcp_relay = 0;
     }
 
     if (call_cb) {
         unsigned int i;
 
-        for (i = 0; i < MAX_FRIEND_CONNECTION_CALLBACKS; ++i) {
-            if (friend_con->callbacks[i].status_callback)
-                friend_con->callbacks[i].status_callback(friend_con->callbacks[i].status_callback_object,
-                        friend_con->callbacks[i].status_callback_id, status);
+        for (i = 0; i < MAX_TOX_CONNECTION_CALLBACKS; ++i) {
+            if (tox_con->callbacks[i].status_callback)
+                tox_con->callbacks[i].status_callback(tox_con->callbacks[i].status_callback_object,
+                        tox_con->callbacks[i].status_callback_id, status);
         }
     }
 
@@ -350,26 +350,26 @@ static int handle_status(void *object, int number, uint8_t status)
 /* Callback for dht public key changes. */
 static void dht_pk_callback(void *object, int32_t number, const uint8_t *dht_public_key)
 {
-    Friend_Connections *fr_c = object;
-    Friend_Conn *friend_con = get_conn(fr_c, number);
+    Tox_Connections *tox_conns = object;
+    Tox_Conn *tox_con = get_conn(tox_conns, number);
 
-    if (!friend_con)
+    if (!tox_con)
         return;
 
-    if (public_key_cmp(friend_con->dht_temp_pk, dht_public_key) == 0)
+    if (public_key_cmp(tox_con->dht_temp_pk, dht_public_key) == 0)
         return;
 
-    change_dht_pk(fr_c, number, dht_public_key);
+    change_dht_pk(tox_conns, number, dht_public_key);
 
     /* if pk changed, create a new connection.*/
-    if (friend_con->crypt_connection_id != -1) {
-        crypto_kill(fr_c->net_crypto, friend_con->crypt_connection_id);
-        friend_con->crypt_connection_id = -1;
+    if (tox_con->crypt_connection_id != -1) {
+        crypto_kill(tox_conns->net_crypto, tox_con->crypt_connection_id);
+        tox_con->crypt_connection_id = -1;
         handle_status(object, number, 0); /* Going offline. */
     }
 
-    friend_new_connection(fr_c, number);
-    onion_set_friend_DHT_pubkey(fr_c->onion_c, friend_con->onion_friendnum, dht_public_key);
+    toxconn_new_connection(tox_conns, number);
+    onion_set_friend_DHT_pubkey(tox_conns->onion_c, tox_con->onion_friendnum, dht_public_key);
 }
 
 static int handle_packet(void *object, int number, uint8_t *data, uint16_t length)
@@ -377,19 +377,19 @@ static int handle_packet(void *object, int number, uint8_t *data, uint16_t lengt
     if (length == 0)
         return -1;
 
-    Friend_Connections *fr_c = object;
-    Friend_Conn *friend_con = get_conn(fr_c, number);
+    Tox_Connections *tox_conns = object;
+    Tox_Conn *tox_con = get_conn(tox_conns, number);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     if (data[0] == PACKET_ID_FRIEND_REQUESTS) {
-        if (fr_c->fr_request_callback)
-            fr_c->fr_request_callback(fr_c->fr_request_object, friend_con->real_public_key, data, length);
+        if (tox_conns->toxconn_request_callback)
+            tox_conns->toxconn_request_callback(tox_conns->toxconn_request_object, tox_con->real_public_key, data, length);
 
         return 0;
     } else if (data[0] == PACKET_ID_ALIVE) {
-        friend_con->ping_lastrecv = unix_time();
+        tox_con->ping_lastrecv = unix_time();
         return 0;
     } else if (data[0] == PACKET_ID_SHARE_RELAYS) {
         Node_format nodes[MAX_SHARED_RELAYS];
@@ -401,7 +401,7 @@ static int handle_packet(void *object, int number, uint8_t *data, uint16_t lengt
         int j;
 
         for (j = 0; j < n; j++) {
-            friend_add_tcp_relay(fr_c, number, nodes[j].ip_port, nodes[j].public_key);
+            toxconn_add_tcp_relay(tox_conns, number, nodes[j].ip_port, nodes[j].public_key);
         }
 
         return 0;
@@ -409,14 +409,14 @@ static int handle_packet(void *object, int number, uint8_t *data, uint16_t lengt
 
     unsigned int i;
 
-    for (i = 0; i < MAX_FRIEND_CONNECTION_CALLBACKS; ++i) {
-        if (friend_con->callbacks[i].data_callback)
-            friend_con->callbacks[i].data_callback(friend_con->callbacks[i].data_callback_object,
-                                                   friend_con->callbacks[i].data_callback_id, data, length);
+    for (i = 0; i < MAX_TOX_CONNECTION_CALLBACKS; ++i) {
+        if (tox_con->callbacks[i].data_callback)
+            tox_con->callbacks[i].data_callback(tox_con->callbacks[i].data_callback_object,
+                                                   tox_con->callbacks[i].data_callback_id, data, length);
 
-        friend_con = get_conn(fr_c, number);
+        tox_con = get_conn(tox_conns, number);
 
-        if (!friend_con)
+        if (!tox_con)
             return -1;
     }
 
@@ -428,22 +428,22 @@ static int handle_lossy_packet(void *object, int number, const uint8_t *data, ui
     if (length == 0)
         return -1;
 
-    Friend_Connections *fr_c = object;
-    Friend_Conn *friend_con = get_conn(fr_c, number);
+    Tox_Connections *tox_conns = object;
+    Tox_Conn *tox_con = get_conn(tox_conns, number);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     unsigned int i;
 
-    for (i = 0; i < MAX_FRIEND_CONNECTION_CALLBACKS; ++i) {
-        if (friend_con->callbacks[i].lossy_data_callback)
-            friend_con->callbacks[i].lossy_data_callback(friend_con->callbacks[i].lossy_data_callback_object,
-                    friend_con->callbacks[i].lossy_data_callback_id, data, length);
+    for (i = 0; i < MAX_TOX_CONNECTION_CALLBACKS; ++i) {
+        if (tox_con->callbacks[i].lossy_data_callback)
+            tox_con->callbacks[i].lossy_data_callback(tox_con->callbacks[i].lossy_data_callback_object,
+                    tox_con->callbacks[i].lossy_data_callback_id, data, length);
 
-        friend_con = get_conn(fr_c, number);
+        tox_con = get_conn(tox_conns, number);
 
-        if (!friend_con)
+        if (!tox_con)
             return -1;
     }
 
@@ -452,180 +452,180 @@ static int handle_lossy_packet(void *object, int number, const uint8_t *data, ui
 
 static int handle_new_connections(void *object, New_Connection *n_c)
 {
-    Friend_Connections *fr_c = object;
-    int friendcon_id = getfriend_conn_id_pk(fr_c, n_c->public_key);
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Connections *tox_conns = object;
+    int toxconn_id = gettox_conn_id_pk(tox_conns, n_c->public_key);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (friend_con) {
+    if (tox_con) {
 
-        if (friend_con->crypt_connection_id != -1)
+        if (tox_con->crypt_connection_id != -1)
             return -1;
 
-        int id = accept_crypto_connection(fr_c->net_crypto, n_c);
+        int id = accept_crypto_connection(tox_conns->net_crypto, n_c);
 
         if (id == -1) {
             return -1;
         }
 
-        connection_status_handler(fr_c->net_crypto, id, &handle_status, fr_c, friendcon_id);
-        connection_data_handler(fr_c->net_crypto, id, &handle_packet, fr_c, friendcon_id);
-        connection_lossy_data_handler(fr_c->net_crypto, id, &handle_lossy_packet, fr_c, friendcon_id);
-        friend_con->crypt_connection_id = id;
+        connection_status_handler(tox_conns->net_crypto, id, &handle_status, tox_conns, toxconn_id);
+        connection_data_handler(tox_conns->net_crypto, id, &handle_packet, tox_conns, toxconn_id);
+        connection_lossy_data_handler(tox_conns->net_crypto, id, &handle_lossy_packet, tox_conns, toxconn_id);
+        tox_con->crypt_connection_id = id;
 
         if (n_c->source.ip.family != AF_INET && n_c->source.ip.family != AF_INET6) {
-            set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, friend_con->dht_ip_port, 0);
+            set_direct_ip_port(tox_conns->net_crypto, tox_con->crypt_connection_id, tox_con->dht_ip_port, 0);
         } else {
-            friend_con->dht_ip_port = n_c->source;
-            friend_con->dht_ip_port_lastrecv = unix_time();
+            tox_con->dht_ip_port = n_c->source;
+            tox_con->dht_ip_port_lastrecv = unix_time();
         }
 
-        if (public_key_cmp(friend_con->dht_temp_pk, n_c->dht_public_key) != 0) {
-            change_dht_pk(fr_c, friendcon_id, n_c->dht_public_key);
+        if (public_key_cmp(tox_con->dht_temp_pk, n_c->dht_public_key) != 0) {
+            change_dht_pk(tox_conns, toxconn_id, n_c->dht_public_key);
         }
 
-        nc_dht_pk_callback(fr_c->net_crypto, id, &dht_pk_callback, fr_c, friendcon_id);
+        nc_dht_pk_callback(tox_conns->net_crypto, id, &dht_pk_callback, tox_conns, toxconn_id);
         return 0;
     }
 
     return -1;
 }
 
-static int friend_new_connection(Friend_Connections *fr_c, int friendcon_id)
+static int toxconn_new_connection(Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
-    if (friend_con->crypt_connection_id != -1) {
+    if (tox_con->crypt_connection_id != -1) {
         return -1;
     }
 
     /* If dht_temp_pk does not contains a pk. */
-    if (!friend_con->dht_lock) {
+    if (!tox_con->dht_lock) {
         return -1;
     }
 
-    int id = new_crypto_connection(fr_c->net_crypto, friend_con->real_public_key, friend_con->dht_temp_pk);
+    int id = new_crypto_connection(tox_conns->net_crypto, tox_con->real_public_key, tox_con->dht_temp_pk);
 
     if (id == -1)
         return -1;
 
-    friend_con->crypt_connection_id = id;
-    connection_status_handler(fr_c->net_crypto, id, &handle_status, fr_c, friendcon_id);
-    connection_data_handler(fr_c->net_crypto, id, &handle_packet, fr_c, friendcon_id);
-    connection_lossy_data_handler(fr_c->net_crypto, id, &handle_lossy_packet, fr_c, friendcon_id);
-    nc_dht_pk_callback(fr_c->net_crypto, id, &dht_pk_callback, fr_c, friendcon_id);
+    tox_con->crypt_connection_id = id;
+    connection_status_handler(tox_conns->net_crypto, id, &handle_status, tox_conns, toxconn_id);
+    connection_data_handler(tox_conns->net_crypto, id, &handle_packet, tox_conns, toxconn_id);
+    connection_lossy_data_handler(tox_conns->net_crypto, id, &handle_lossy_packet, tox_conns, toxconn_id);
+    nc_dht_pk_callback(tox_conns->net_crypto, id, &dht_pk_callback, tox_conns, toxconn_id);
 
     return 0;
 }
 
-static int send_ping(const Friend_Connections *fr_c, int friendcon_id)
+static int send_ping(const Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     uint8_t ping = PACKET_ID_ALIVE;
-    int64_t ret = write_cryptpacket(fr_c->net_crypto, friend_con->crypt_connection_id, &ping, sizeof(ping), 0);
+    int64_t ret = write_cryptpacket(tox_conns->net_crypto, tox_con->crypt_connection_id, &ping, sizeof(ping), 0);
 
     if (ret != -1) {
-        friend_con->ping_lastsent = unix_time();
+        tox_con->ping_lastsent = unix_time();
         return 0;
     }
 
     return -1;
 }
 
-/* Increases lock_count for the connection with friendcon_id by 1.
+/* Increases lock_count for the connection with toxconn_id by 1.
  *
  * return 0 on success.
  * return -1 on failure.
  */
-int friend_connection_lock(Friend_Connections *fr_c, int friendcon_id)
+int tox_connection_lock(Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
-    ++friend_con->lock_count;
+    ++tox_con->lock_count;
     return 0;
 }
 
-/* return FRIENDCONN_STATUS_CONNECTED if the friend is connected.
- * return FRIENDCONN_STATUS_CONNECTING if the friend isn't connected.
- * return FRIENDCONN_STATUS_NONE on failure.
+/* return TOXCONN_STATUS_CONNECTED if the peer is connected.
+ * return TOXCONN_STATUS_CONNECTING if the peer isn't connected.
+ * return TOXCONN_STATUS_NONE on failure.
  */
-unsigned int friend_con_connected(Friend_Connections *fr_c, int friendcon_id)
+unsigned int tox_conn_is_connected(Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return 0;
 
-    return friend_con->status;
+    return tox_con->status;
 }
 
-/* Copy public keys associated to friendcon_id.
+/* Copy public keys associated to toxconn_id.
  *
  * return 0 on success.
  * return -1 on failure.
  */
-int get_friendcon_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Friend_Connections *fr_c, int friendcon_id)
+int tox_conn_get_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     if (real_pk)
-        memcpy(real_pk, friend_con->real_public_key, crypto_box_PUBLICKEYBYTES);
+        memcpy(real_pk, tox_con->real_public_key, crypto_box_PUBLICKEYBYTES);
 
     if (dht_temp_pk)
-        memcpy(dht_temp_pk, friend_con->dht_temp_pk, crypto_box_PUBLICKEYBYTES);
+        memcpy(dht_temp_pk, tox_con->dht_temp_pk, crypto_box_PUBLICKEYBYTES);
 
     return 0;
 }
 
-/* Set temp dht key for connection.
- */
-void set_dht_temp_pk(Friend_Connections *fr_c, int friendcon_id, const uint8_t *dht_temp_pk)
+/* Set temp dht key for connection. */
+void set_dht_temp_pk(Tox_Connections *tox_conns, int toxconn_id, const uint8_t *dht_temp_pk)
 {
-    dht_pk_callback(fr_c, friendcon_id, dht_temp_pk);
+    dht_pk_callback(tox_conns, toxconn_id, dht_temp_pk);
 }
 
-/* Set the callbacks for the friend connection.
- * index is the index (0 to (MAX_FRIEND_CONNECTION_CALLBACKS - 1)) we want the callback to set in the array.
+/* Set the callbacks for the given connection.
+ * index is the index (0 to (MAX_TOX_CONNECTION_CALLBACKS - 1)) we want the callback to set in the array.
  *
  * return 0 on success.
  * return -1 on failure
  */
-int friend_connection_callbacks(Friend_Connections *fr_c, int friendcon_id, unsigned int index,
-                                int (*status_callback)(void *object, int id, uint8_t status), int (*data_callback)(void *object, int id, uint8_t *data,
-                                        uint16_t length), int (*lossy_data_callback)(void *object, int id, const uint8_t *data, uint16_t length), void *object,
-                                int number)
+int tox_conn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned int index,
+                                int (*status_callback)(void *object, int id, uint8_t status),
+                                int (*data_callback)(void *object, int id, uint8_t *data, uint16_t length),
+                                int (*lossy_data_callback)(void *object, int id, const uint8_t *data, uint16_t length),
+                                void *object, int number)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
-    if (index >= MAX_FRIEND_CONNECTION_CALLBACKS)
+    if (index >= MAX_TOX_CONNECTION_CALLBACKS)
         return -1;
 
-    friend_con->callbacks[index].status_callback = status_callback;
-    friend_con->callbacks[index].data_callback = data_callback;
-    friend_con->callbacks[index].lossy_data_callback = lossy_data_callback;
+    tox_con->callbacks[index].status_callback = status_callback;
+    tox_con->callbacks[index].data_callback = data_callback;
+    tox_con->callbacks[index].lossy_data_callback = lossy_data_callback;
 
-    friend_con->callbacks[index].status_callback_object =
-        friend_con->callbacks[index].data_callback_object =
-            friend_con->callbacks[index].lossy_data_callback_object = object;
+    tox_con->callbacks[index].status_callback_object =
+        tox_con->callbacks[index].data_callback_object =
+            tox_con->callbacks[index].lossy_data_callback_object = object;
 
-    friend_con->callbacks[index].status_callback_id =
-        friend_con->callbacks[index].data_callback_id =
-            friend_con->callbacks[index].lossy_data_callback_id = number;
+    tox_con->callbacks[index].status_callback_id =
+        tox_con->callbacks[index].data_callback_id =
+            tox_con->callbacks[index].lossy_data_callback_id = number;
     return 0;
 }
 
@@ -634,121 +634,122 @@ int friend_connection_callbacks(Friend_Connections *fr_c, int friendcon_id, unsi
  * return crypt_connection_id on success.
  * return -1 on failure.
  */
-int friend_connection_crypt_connection_id(Friend_Connections *fr_c, int friendcon_id)
+int tox_conn_crypt_connection_id(Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
-    return friend_con->crypt_connection_id;
+    return tox_con->crypt_connection_id;
 }
 
-/* Create a new friend connection.
+/* Create a new connection.
  * If one to that real public key already exists, increase lock count and return it.
  *
  * return -1 on failure.
  * return connection id on success.
  */
-int new_friend_connection(Friend_Connections *fr_c, const uint8_t *real_public_key)
+int new_tox_conn(Tox_Connections *tox_conns, const uint8_t *real_public_key)
 {
-    int friendcon_id = getfriend_conn_id_pk(fr_c, real_public_key);
+    int toxconn_id = gettox_conn_id_pk(tox_conns, real_public_key);
 
-    if (friendcon_id != -1) {
-        ++fr_c->conns[friendcon_id].lock_count;
-        return friendcon_id;
+    if (toxconn_id != -1) {
+        ++tox_conns->conns[toxconn_id].lock_count;
+        return toxconn_id;
     }
 
-    friendcon_id = create_friend_conn(fr_c);
+    toxconn_id = create_toxconn(tox_conns);
 
-    if (friendcon_id == -1)
+    if (toxconn_id == -1)
         return -1;
 
-    int32_t onion_friendnum = onion_addfriend(fr_c->onion_c, real_public_key);
+    int32_t onion_friendnum = onion_addfriend(tox_conns->onion_c, real_public_key);
 
     if (onion_friendnum == -1)
         return -1;
 
-    Friend_Conn *friend_con = &fr_c->conns[friendcon_id];
+    Tox_Conn *tox_con = &tox_conns->conns[toxconn_id];
 
-    friend_con->crypt_connection_id = -1;
-    friend_con->status = FRIENDCONN_STATUS_CONNECTING;
-    memcpy(friend_con->real_public_key, real_public_key, crypto_box_PUBLICKEYBYTES);
-    friend_con->onion_friendnum = onion_friendnum;
+    tox_con->crypt_connection_id = -1;
+    tox_con->status = TOXCONN_STATUS_CONNECTING;
+    memcpy(tox_con->real_public_key, real_public_key, crypto_box_PUBLICKEYBYTES);
+    tox_con->onion_friendnum = onion_friendnum;
 
-    recv_tcp_relay_handler(fr_c->onion_c, onion_friendnum, &tcp_relay_node_callback, fr_c, friendcon_id);
-    onion_dht_pk_callback(fr_c->onion_c, onion_friendnum, &dht_pk_callback, fr_c, friendcon_id);
+    recv_tcp_relay_handler(tox_conns->onion_c, onion_friendnum, &tcp_relay_node_callback, tox_conns, toxconn_id);
+    onion_dht_pk_callback(tox_conns->onion_c, onion_friendnum, &dht_pk_callback, tox_conns, toxconn_id);
 
-    return friendcon_id;
+    return toxconn_id;
 }
 
-/* Kill a friend connection.
+/* Kill a connection.
  *
  * return -1 on failure.
  * return 0 on success.
  */
-int kill_friend_connection(Friend_Connections *fr_c, int friendcon_id)
+int kill_tox_conn(Tox_Connections *tox_conns, int toxconn_id)
 {
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
-    if (friend_con->lock_count) {
-        --friend_con->lock_count;
+    if (tox_con->lock_count) {
+        --tox_con->lock_count;
         return 0;
     }
 
-    onion_delfriend(fr_c->onion_c, friend_con->onion_friendnum);
-    crypto_kill(fr_c->net_crypto, friend_con->crypt_connection_id);
+    onion_delfriend(tox_conns->onion_c, tox_con->onion_friendnum);
+    crypto_kill(tox_conns->net_crypto, tox_con->crypt_connection_id);
 
-    if (friend_con->dht_lock) {
-        DHT_delfriend(fr_c->dht, friend_con->dht_temp_pk, friend_con->dht_lock);
+    if (tox_con->dht_lock) {
+        DHT_delfriend(tox_conns->dht, tox_con->dht_temp_pk, tox_con->dht_lock);
     }
 
-    return wipe_friend_conn(fr_c, friendcon_id);
+    return wipe_tox_conn(tox_conns, toxconn_id);
 }
 
 
-/* Set friend request callback.
+/* Set connection request callback.
  *
- * This function will be called every time a friend request packet is received.
+ * This function will be called every time any connection request packet is received.
  */
-void set_friend_request_callback(Friend_Connections *fr_c, int (*fr_request_callback)(void *, const uint8_t *,
-                                 const uint8_t *, uint16_t), void *object)
+void set_tox_conn_request_callback(Tox_Connections *tox_conns,
+                                   int (*toxconn_request_callback)(void *, const uint8_t *, const uint8_t *, uint16_t),
+                                   void *object)
 {
-    fr_c->fr_request_callback = fr_request_callback;
-    fr_c->fr_request_object = object;
-    oniondata_registerhandler(fr_c->onion_c, CRYPTO_PACKET_FRIEND_REQ, fr_request_callback, object);
+    tox_conns->toxconn_request_callback = toxconn_request_callback;
+    tox_conns->toxconn_request_object = object;
+    oniondata_registerhandler(tox_conns->onion_c, CRYPTO_PACKET_FRIEND_REQ, toxconn_request_callback, object);
 }
 
-/* Send a Friend request packet.
+/* Send a connection request packet.
  *
  *  return -1 if failure.
  *  return  0 if it sent the friend request directly to the friend.
  *  return the number of peers it was routed through if it did not send it directly.
  */
-int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint32_t nospam_num, const uint8_t *data,
+int send_tox_conn_request_pkt(Tox_Connections *tox_conns, int toxconn_id, uint32_t nospam_num, const uint8_t *data,
                                uint16_t length)
 {
     if (1 + sizeof(nospam_num) + length > ONION_CLIENT_MAX_DATA_SIZE || length == 0)
         return -1;
 
-    Friend_Conn *friend_con = get_conn(fr_c, friendcon_id);
+    Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
-    if (!friend_con)
+    if (!tox_con)
         return -1;
 
     uint8_t packet[1 + sizeof(nospam_num) + length];
     memcpy(packet + 1, &nospam_num, sizeof(nospam_num));
     memcpy(packet + 1 + sizeof(nospam_num), data, length);
 
-    if (friend_con->status == FRIENDCONN_STATUS_CONNECTED) {
+    if (tox_con->status == TOXCONN_STATUS_CONNECTED) {
         packet[0] = PACKET_ID_FRIEND_REQUESTS;
-        return write_cryptpacket(fr_c->net_crypto, friend_con->crypt_connection_id, packet, sizeof(packet), 0) != -1;
+        return write_cryptpacket(tox_conns->net_crypto, tox_con->crypt_connection_id, packet, sizeof(packet), 0) != -1;
     } else {
         packet[0] = CRYPTO_PACKET_FRIEND_REQ;
-        int num = send_onion_data(fr_c->onion_c, friend_con->onion_friendnum, packet, sizeof(packet));
+        int num = send_onion_data(tox_conns->onion_c, tox_con->onion_friendnum, packet, sizeof(packet));
 
         if (num <= 0)
             return -1;
@@ -757,13 +758,13 @@ int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint3
     }
 }
 
-/* Create new friend_connections instance. */
-Friend_Connections *new_friend_connections(Onion_Client *onion_c)
+/* Create new Tox_Connections instance. */
+Tox_Connections *new_tox_conns(Onion_Client *onion_c)
 {
     if (!onion_c)
         return NULL;
 
-    Friend_Connections *temp = calloc(1, sizeof(Friend_Connections));
+    Tox_Connections *temp = calloc(1, sizeof(Tox_Connections));
 
     if (temp == NULL)
         return NULL;
@@ -779,77 +780,77 @@ Friend_Connections *new_friend_connections(Onion_Client *onion_c)
 }
 
 /* Send a LAN discovery packet every LAN_DISCOVERY_INTERVAL seconds. */
-static void LANdiscovery(Friend_Connections *fr_c)
+static void LANdiscovery(Tox_Connections *tox_conns)
 {
-    if (fr_c->last_LANdiscovery + LAN_DISCOVERY_INTERVAL < unix_time()) {
-        send_LANdiscovery(htons(TOX_PORT_DEFAULT), fr_c->dht);
-        fr_c->last_LANdiscovery = unix_time();
+    if (tox_conns->last_LANdiscovery + LAN_DISCOVERY_INTERVAL < unix_time()) {
+        send_LANdiscovery(htons(TOX_PORT_DEFAULT), tox_conns->dht);
+        tox_conns->last_LANdiscovery = unix_time();
     }
 }
 
-/* main friend_connections loop. */
-void do_friend_connections(Friend_Connections *fr_c)
+/* main Tox_Connections loop. */
+void do_tox_connections(Tox_Connections *tox_conns)
 {
     uint32_t i;
     uint64_t temp_time = unix_time();
 
-    for (i = 0; i < fr_c->num_cons; ++i) {
-        Friend_Conn *friend_con = get_conn(fr_c, i);
+    for (i = 0; i < tox_conns->num_cons; ++i) {
+        Tox_Conn *tox_con = get_conn(tox_conns, i);
 
-        if (friend_con) {
-            if (friend_con->status == FRIENDCONN_STATUS_CONNECTING) {
-                if (friend_con->dht_pk_lastrecv + FRIEND_DHT_TIMEOUT < temp_time) {
-                    if (friend_con->dht_lock) {
-                        DHT_delfriend(fr_c->dht, friend_con->dht_temp_pk, friend_con->dht_lock);
-                        friend_con->dht_lock = 0;
+        if (tox_con) {
+            if (tox_con->status == TOXCONN_STATUS_CONNECTING) {
+                if (tox_con->dht_pk_lastrecv + FRIEND_DHT_TIMEOUT < temp_time) {
+                    if (tox_con->dht_lock) {
+                        DHT_delfriend(tox_conns->dht, tox_con->dht_temp_pk, tox_con->dht_lock);
+                        tox_con->dht_lock = 0;
                     }
                 }
 
-                if (friend_con->dht_ip_port_lastrecv + FRIEND_DHT_TIMEOUT < temp_time) {
-                    friend_con->dht_ip_port.ip.family = 0;
+                if (tox_con->dht_ip_port_lastrecv + FRIEND_DHT_TIMEOUT < temp_time) {
+                    tox_con->dht_ip_port.ip.family = 0;
                 }
 
-                if (friend_con->dht_lock) {
-                    if (friend_new_connection(fr_c, i) == 0) {
-                        set_direct_ip_port(fr_c->net_crypto, friend_con->crypt_connection_id, friend_con->dht_ip_port, 0);
-                        connect_to_saved_tcp_relays(fr_c, i, (MAX_FRIEND_TCP_CONNECTIONS / 2)); /* Only fill it half up. */
+                if (tox_con->dht_lock) {
+                    if (toxconn_new_connection(tox_conns, i) == 0) {
+                        set_direct_ip_port(tox_conns->net_crypto, tox_con->crypt_connection_id, tox_con->dht_ip_port, 0);
+                        connect_to_saved_tcp_relays(tox_conns, i, (MAX_TCP_CONNECTIONS / 2)); /* Only fill it half up. */
                     }
                 }
 
-            } else if (friend_con->status == FRIENDCONN_STATUS_CONNECTED) {
-                if (friend_con->ping_lastsent + FRIEND_PING_INTERVAL < temp_time) {
-                    send_ping(fr_c, i);
+            } else if (tox_con->status == TOXCONN_STATUS_CONNECTED) {
+                if (tox_con->ping_lastsent + TOXCONN_PING_INTERVAL < temp_time) {
+                    send_ping(tox_conns, i);
                 }
 
-                if (friend_con->share_relays_lastsent + SHARE_RELAYS_INTERVAL < temp_time) {
-                    send_relays(fr_c, i);
+                if (tox_con->share_relays_lastsent + SHARE_RELAYS_INTERVAL < temp_time) {
+                    send_relays(tox_conns, i);
                 }
 
-                if (friend_con->ping_lastrecv + FRIEND_CONNECTION_TIMEOUT < temp_time) {
+                if (tox_con->ping_lastrecv + TOXCONN_TIMEOUT < temp_time) {
                     /* If we stopped receiving ping packets, kill it. */
-                    crypto_kill(fr_c->net_crypto, friend_con->crypt_connection_id);
-                    friend_con->crypt_connection_id = -1;
-                    handle_status(fr_c, i, 0); /* Going offline. */
+                    crypto_kill(tox_conns->net_crypto, tox_con->crypt_connection_id);
+                    tox_con->crypt_connection_id = -1;
+                    handle_status(tox_conns, i, 0); /* Going offline. */
                 }
             }
         }
     }
 
-    LANdiscovery(fr_c);
+    LANdiscovery(tox_conns);
 }
 
-/* Free everything related with friend_connections. */
-void kill_friend_connections(Friend_Connections *fr_c)
+/* Free everything related with given Tox_Connections. */
+void kill_tox_conns(Tox_Connections *tox_conns)
 {
-    if (!fr_c)
+    if (!tox_conns)
         return;
 
     uint32_t i;
 
-    for (i = 0; i < fr_c->num_cons; ++i) {
-        kill_friend_connection(fr_c, i);
+    for (i = 0; i < tox_conns->num_cons; ++i) {
+        kill_tox_conn(tox_conns, i);
     }
 
-    LANdiscovery_kill(fr_c->dht);
-    free(fr_c);
+    LANdiscovery_kill(tox_conns->dht);
+    free(tox_conns);
 }

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -138,7 +138,7 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, co
     return 0;
 }
 
-void friendreq_init(Friend_Requests *fr, Friend_Connections *fr_c)
+void friendreq_init(Friend_Requests *fr, Tox_Connections *fr_c)
 {
-    set_friend_request_callback(fr_c, &friendreq_handlepacket, fr);
+    set_tox_conn_request_callback(fr_c, &friendreq_handlepacket, fr);
 }

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -140,5 +140,5 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, co
 
 void friendreq_init(Friend_Requests *fr, Tox_Connections *fr_c)
 {
-    set_tox_conn_request_callback(fr_c, &friendreq_handlepacket, fr);
+    set_toxconn_request_callback(fr_c, &friendreq_handlepacket, fr);
 }

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -71,7 +71,7 @@ void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const 
 void set_filter_function(Friend_Requests *fr, int (*function)(const uint8_t *, void *), void *userdata);
 
 /* Sets up friendreq packet handlers. */
-void friendreq_init(Friend_Requests *fr, Friend_Connections *fr_c);
+void friendreq_init(Friend_Requests *fr, Tox_Connections *fr_c);
 
 
 #endif

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -24,7 +24,7 @@
 #ifndef FRIEND_REQUESTS_H
 #define FRIEND_REQUESTS_H
 
-#include "friend_connection.h"
+#include "tox_connection.h"
 
 #define MAX_FRIEND_REQUEST_DATA_SIZE (ONION_CLIENT_MAX_DATA_SIZE - (1 + sizeof(uint32_t)))
 

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -307,7 +307,7 @@ static unsigned int pk_in_closest_peers(Group_c *g, uint8_t *real_pk)
     return 0;
 }
 
-static int send_packet_online(Friend_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier);
+static int send_packet_online(Tox_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier);
 
 static int connect_to_closest(Group_Chats *g_c, int groupnumber)
 {
@@ -336,11 +336,11 @@ static int connect_to_closest(Group_Chats *g_c, int groupnumber)
 
         uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
         uint8_t dht_temp_pk[crypto_box_PUBLICKEYBYTES];
-        get_friendcon_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[i].number);
+        tox_conn_get_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[i].number);
 
         if (!pk_in_closest_peers(g, real_pk)) {
             g->close[i].type = GROUPCHAT_CLOSE_NONE;
-            kill_friend_connection(g_c->fr_c, g->close[i].number);
+            kill_tox_conn(g_c->fr_c, g->close[i].number);
         }
     }
 
@@ -348,12 +348,12 @@ static int connect_to_closest(Group_Chats *g_c, int groupnumber)
         if (!g->closest_peers[i].entry)
             continue;
 
-        int friendcon_id = getfriend_conn_id_pk(g_c->fr_c, g->closest_peers[i].real_pk);
+        int friendcon_id = gettox_conn_id_pk(g_c->fr_c, g->closest_peers[i].real_pk);
 
         uint8_t lock = 1;
 
         if (friendcon_id == -1) {
-            friendcon_id = new_friend_connection(g_c->fr_c, g->closest_peers[i].real_pk);
+            friendcon_id = new_tox_conn(g_c->fr_c, g->closest_peers[i].real_pk);
             lock = 0;
 
             if (friendcon_id == -1) {
@@ -365,7 +365,7 @@ static int connect_to_closest(Group_Chats *g_c, int groupnumber)
 
         add_conn_to_groupchat(g_c, friendcon_id, groupnumber, 1, lock);
 
-        if (friend_con_connected(g_c->fr_c, friendcon_id) == FRIENDCONN_STATUS_CONNECTED) {
+        if (tox_conn_is_connected(g_c->fr_c, friendcon_id) == TOXCONN_STATUS_CONNECTED) {
             send_packet_online(g_c->fr_c, friendcon_id, groupnumber, g->identifier);
         }
     }
@@ -449,7 +449,7 @@ static int remove_close_conn(Group_Chats *g_c, int groupnumber, int friendcon_id
 
         if (g->close[i].number == (unsigned int)friendcon_id) {
             g->close[i].type = GROUPCHAT_CLOSE_NONE;
-            kill_friend_connection(g_c->fr_c, friendcon_id);
+            kill_tox_conn(g_c->fr_c, friendcon_id);
             return 0;
         }
     }
@@ -481,7 +481,7 @@ static int delpeer(Group_Chats *g_c, int groupnumber, int peer_index)
         }
     }
 
-    int friendcon_id = getfriend_conn_id_pk(g_c->fr_c, g->group[peer_index].real_pk);
+    int friendcon_id = gettox_conn_id_pk(g_c->fr_c, g->group[peer_index].real_pk);
 
     if (friendcon_id != -1) {
         remove_close_conn(g_c, groupnumber, friendcon_id);
@@ -645,13 +645,13 @@ static int add_conn_to_groupchat(Group_Chats *g_c, int friendcon_id, int groupnu
         return -1;
 
     if (lock)
-        friend_connection_lock(g_c->fr_c, friendcon_id);
+        tox_connection_lock(g_c->fr_c, friendcon_id);
 
     g->close[ind].type = GROUPCHAT_CLOSE_CONNECTION;
     g->close[ind].number = friendcon_id;
     g->close[ind].closest = closest;
     //TODO
-    friend_connection_callbacks(g_c->m->fr_c, friendcon_id, GROUPCHAT_CALLBACK_INDEX, &handle_status, &handle_packet,
+    tox_conn_set_callbacks(g_c->m->fr_c, friendcon_id, GROUPCHAT_CALLBACK_INDEX, &handle_status, &handle_packet,
                                 &handle_lossy, g_c, friendcon_id);
 
     return ind;
@@ -712,7 +712,7 @@ int del_groupchat(Group_Chats *g_c, int groupnumber)
             continue;
 
         g->close[i].type = GROUPCHAT_CLOSE_NONE;
-        kill_friend_connection(g_c->fr_c, g->close[i].number);
+        kill_tox_conn(g_c->fr_c, g->close[i].number);
     }
 
     for (i = 0; i < g->numpeers; ++i) {
@@ -852,7 +852,7 @@ int group_get_type(const Group_Chats *g_c, int groupnumber)
  *  return 1 on success
  *  return 0 on failure
  */
-static unsigned int send_packet_group_peer(Friend_Connections *fr_c, int friendcon_id, uint8_t packet_id,
+static unsigned int send_packet_group_peer(Tox_Connections *fr_c, int friendcon_id, uint8_t packet_id,
         uint16_t group_num, const uint8_t *data, uint16_t length)
 {
     if (1 + sizeof(uint16_t) + length > MAX_CRYPTO_DATA_SIZE)
@@ -863,7 +863,7 @@ static unsigned int send_packet_group_peer(Friend_Connections *fr_c, int friendc
     packet[0] = packet_id;
     memcpy(packet + 1, &group_num, sizeof(uint16_t));
     memcpy(packet + 1 + sizeof(uint16_t), data, length);
-    return write_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, friendcon_id), packet,
+    return write_cryptpacket(fr_c->net_crypto, tox_conn_crypt_connection_id(fr_c, friendcon_id), packet,
                              sizeof(packet), 0) != -1;
 }
 
@@ -872,7 +872,7 @@ static unsigned int send_packet_group_peer(Friend_Connections *fr_c, int friendc
  *  return 1 on success
  *  return 0 on failure
  */
-static unsigned int send_lossy_group_peer(Friend_Connections *fr_c, int friendcon_id, uint8_t packet_id,
+static unsigned int send_lossy_group_peer(Tox_Connections *fr_c, int friendcon_id, uint8_t packet_id,
         uint16_t group_num, const uint8_t *data, uint16_t length)
 {
     if (1 + sizeof(uint16_t) + length > MAX_CRYPTO_DATA_SIZE)
@@ -883,7 +883,7 @@ static unsigned int send_lossy_group_peer(Friend_Connections *fr_c, int friendco
     packet[0] = packet_id;
     memcpy(packet + 1, &group_num, sizeof(uint16_t));
     memcpy(packet + 1 + sizeof(uint16_t), data, length);
-    return send_lossy_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, friendcon_id), packet,
+    return send_lossy_cryptpacket(fr_c->net_crypto, tox_conn_crypt_connection_id(fr_c, friendcon_id), packet,
                                   sizeof(packet)) != -1;
 }
 
@@ -1298,7 +1298,7 @@ static void handle_friend_invite_packet(Messenger *m, uint32_t friendnumber, con
 
             int friendcon_id = getfriendcon_id(m, friendnumber);
             uint8_t real_pk[crypto_box_PUBLICKEYBYTES], temp_pk[crypto_box_PUBLICKEYBYTES];
-            get_friendcon_public_keys(real_pk, temp_pk, g_c->fr_c, friendcon_id);
+            tox_conn_get_public_keys(real_pk, temp_pk, g_c->fr_c, friendcon_id);
 
             addpeer(g_c, groupnum, real_pk, temp_pk, peer_number);
             int close_index = add_conn_to_groupchat(g_c, friendcon_id, groupnum, 0, 1);
@@ -1356,14 +1356,14 @@ static unsigned int count_close_connected(Group_c *g)
 
 #define ONLINE_PACKET_DATA_SIZE (sizeof(uint16_t) + GROUP_IDENTIFIER_LENGTH)
 
-static int send_packet_online(Friend_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier)
+static int send_packet_online(Tox_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier)
 {
     uint8_t packet[1 + ONLINE_PACKET_DATA_SIZE];
     group_num = htons(group_num);
     packet[0] = PACKET_ID_ONLINE_PACKET;
     memcpy(packet + 1, &group_num, sizeof(uint16_t));
     memcpy(packet + 1 + sizeof(uint16_t), identifier, GROUP_IDENTIFIER_LENGTH);
-    return write_cryptpacket(fr_c->net_crypto, friend_connection_crypt_connection_id(fr_c, friendcon_id), packet,
+    return write_cryptpacket(fr_c->net_crypto, tox_conn_crypt_connection_id(fr_c, friendcon_id), packet,
                              sizeof(packet), 0) != -1;
 }
 
@@ -1410,7 +1410,7 @@ static int handle_packet_online(Group_Chats *g_c, int friendcon_id, uint8_t *dat
         if (!g->close[fr_close_index].closest) {
             g->close[fr_close_index].type = GROUPCHAT_CLOSE_NONE;
             send_peer_kill(g_c, g->close[fr_close_index].number, g->close[fr_close_index].group_number);
-            kill_friend_connection(g_c->fr_c, g->close[fr_close_index].number);
+            kill_tox_conn(g_c->fr_c, g->close[fr_close_index].number);
             g->number_joined = -1;
         }
     }
@@ -1560,7 +1560,7 @@ static void handle_direct_packet(Group_Chats *g_c, int groupnumber, const uint8_
 
             if (!g->close[close_index].closest) {
                 g->close[close_index].type = GROUPCHAT_CLOSE_NONE;
-                kill_friend_connection(g_c->fr_c, g->close[close_index].number);
+                kill_tox_conn(g_c->fr_c, g->close[close_index].number);
             }
         }
 
@@ -1666,7 +1666,7 @@ static unsigned int send_lossy_all_close(const Group_Chats *g_c, int groupnumber
     for (i = 0; i < num_connected_closest; ++i) {
         uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
         uint8_t dht_temp_pk[crypto_box_PUBLICKEYBYTES];
-        get_friendcon_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[connected_closest[i]].number);
+        tox_conn_get_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[connected_closest[i]].number);
         uint64_t comp_val = calculate_comp_value(g->real_pk, real_pk);
 
         if (comp_val < comp_val_old) {
@@ -1686,7 +1686,7 @@ static unsigned int send_lossy_all_close(const Group_Chats *g_c, int groupnumber
     for (i = 0; i < num_connected_closest; ++i) {
         uint8_t real_pk[crypto_box_PUBLICKEYBYTES];
         uint8_t dht_temp_pk[crypto_box_PUBLICKEYBYTES];
-        get_friendcon_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[connected_closest[i]].number);
+        tox_conn_get_public_keys(real_pk, dht_temp_pk, g_c->fr_c, g->close[connected_closest[i]].number);
         uint64_t comp_val = calculate_comp_value(real_pk, g->real_pk);
 
         if (comp_val < comp_val_old) {

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -111,7 +111,7 @@ typedef struct {
 
 typedef struct {
     Messenger *m;
-    Friend_Connections *fr_c;
+    Tox_Connections *fr_c;
 
     Group_c *chats;
     uint32_t num_chats;

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -188,7 +188,9 @@ typedef struct {
     uint8_t cookie_length;
 } New_Connection;
 
-typedef struct {
+typedef struct Net_Crypto {
+    uint32_t nospam;
+
     DHT *dht;
     TCP_Connections *tcp_c;
 
@@ -215,7 +217,6 @@ typedef struct {
 
     BS_LIST ip_port_list;
 } Net_Crypto;
-
 
 /* Set function to be called when someone requests a new connection to us.
  *

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -297,7 +297,7 @@ typedef struct {
     void *object;
 } Packet_Handles;
 
-typedef struct {
+typedef struct Networking_Core {
     Packet_Handles packethandlers[256];
 
     sa_family_t family;

--- a/toxcore/onion.h
+++ b/toxcore/onion.h
@@ -25,7 +25,7 @@
 
 #include "DHT.h"
 
-typedef struct {
+struct Onion {
     DHT     *dht;
     Networking_Core *net;
     uint8_t secret_symmetric_key[crypto_box_KEYBYTES];
@@ -37,7 +37,9 @@ typedef struct {
 
     int (*recv_1_function)(void *, IP_Port, const uint8_t *, uint16_t);
     void *callback_object;
-} Onion;
+};
+
+typedef struct Onion Onion;
 
 #define ONION_MAX_PACKET_SIZE 1400
 

--- a/toxcore/onion_announce.h
+++ b/toxcore/onion_announce.h
@@ -53,7 +53,7 @@ typedef struct {
     uint64_t time;
 } Onion_Announce_Entry;
 
-typedef struct {
+struct Onion_Announce {
     DHT     *dht;
     Networking_Core *net;
     Onion_Announce_Entry entries[ONION_ANNOUNCE_MAX_ENTRIES];
@@ -61,7 +61,9 @@ typedef struct {
     uint8_t secret_bytes[crypto_box_KEYBYTES];
 
     Shared_Keys shared_keys_recv;
-} Onion_Announce;
+};
+
+typedef struct Onion_Announce Onion_Announce;
 
 /* Create an onion announce request packet in packet of max_packet_length (recommended size ONION_ANNOUNCE_REQUEST_SIZE).
  *

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -124,7 +124,7 @@ typedef struct {
 typedef int (*oniondata_handler_callback)(void *object, const uint8_t *source_pubkey, const uint8_t *data,
         uint16_t len);
 
-typedef struct {
+struct Onion_Client {
     DHT     *dht;
     Net_Crypto *c;
     Networking_Core *net;
@@ -161,8 +161,9 @@ typedef struct {
 
     unsigned int onion_connected;
     _Bool UDP_connected;
-} Onion_Client;
+};
 
+typedef struct Onion_Client Onion_Client;
 
 /* Add a node to the path_nodes bootstrap array.
  *

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -28,11 +28,12 @@
 #include "Messenger.h"
 #include "group.h"
 #include "logger.h"
+#include "util.h"
 
 #include "../toxencryptsave/defines.h"
 
 #define TOX_DEFINED
-typedef struct Messenger Tox;
+typedef struct Tox Tox;
 
 #include "tox.h"
 
@@ -129,7 +130,7 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
     if (!logger_get_global())
         logger_set_global(logger_new(LOGGER_OUTPUT_FILE, LOGGER_LEVEL, "toxcore"));
 
-    Messenger_Options m_options = {0};
+    Messenger_Options    m_options = {0};
 
     _Bool load_savedata_sk = 0, load_savedata_tox = 0;
 
@@ -164,11 +165,11 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
             load_savedata_tox = 1;
         }
 
-        m_options.ipv6enabled = options->ipv6_enabled;
-        m_options.udp_disabled = !options->udp_enabled;
-        m_options.port_range[0] = options->start_port;
-        m_options.port_range[1] = options->end_port;
-        m_options.tcp_server_port = options->tcp_port;
+        m_options.ipv6enabled       = options->ipv6_enabled;
+        m_options.udp_disabled      = !options->udp_enabled;
+        m_options.port_range[0]     = options->start_port;
+        m_options.port_range[1]     = options->end_port;
+        m_options.tcp_server_port   = options->tcp_port;
 
         switch (options->proxy_type) {
             case TOX_PROXY_TYPE_HTTP:
@@ -209,11 +210,85 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
         }
     }
 
-    unsigned int m_error;
-    Messenger *m = new_messenger(&m_options, &m_error);
+    Tox *tox = calloc(1, sizeof(Tox));
 
-    if (!new_groupchats(m)) {
-        kill_messenger(m);
+    if (!tox) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
+        return NULL;
+    }
+
+
+    unsigned int net_err = 0;
+
+    if (m_options.udp_disabled) {
+        /* this is the easiest way to completely disable UDP without changing too much code. */
+        tox->net = calloc(1, sizeof(Networking_Core));
+    } else {
+        IP ip;
+        ip_init(&ip, m_options.ipv6enabled);
+        tox->net = new_networking_ex(ip, m_options.port_range[0], m_options.port_range[1], &net_err);
+    }
+
+    if (tox->net == NULL) {
+        free(tox);
+
+        if (error && net_err == 1) {
+            SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PORT_ALLOC);
+        } else {
+            SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
+        }
+
+        return NULL;
+    }
+
+    tox->dht = new_DHT(tox->net);
+
+    if (tox->dht == NULL) {
+        kill_networking(tox->net);
+        free(tox);
+        SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
+        return NULL;
+    }
+
+    tox->net_crypto = new_net_crypto(tox->dht, &m_options.proxy_info);
+
+    if (tox->net_crypto == NULL) {
+        kill_networking(tox->net);
+        kill_DHT(tox->dht);
+        free(tox);
+        SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
+        return NULL;
+    }
+
+    tox->onion    = new_onion(tox->dht);
+    tox->onion_a  = new_onion_announce(tox->dht);
+    tox->onion_c  = new_onion_client(tox->net_crypto);
+
+    if (!(tox->onion && tox->onion_a && tox->onion_c)) {
+        kill_onion(tox->onion);
+        kill_onion_announce(tox->onion_a);
+        kill_onion_client(tox->onion_c);
+        kill_net_crypto(tox->net_crypto);
+        kill_DHT(tox->dht);
+        kill_networking(tox->net);
+        free(tox);
+        SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
+        return NULL;
+    }
+
+    unsigned int m_error;
+
+    tox->tox_conn = new_tox_conns(tox->onion_c);
+
+    Messenger *m = new_messenger(tox, &m_options, &m_error);
+    if (!m) {
+        SET_ERROR_PARAMETER(error, TOX_ERR_NEW_MALLOC);
+        return NULL;
+    }
+    tox->m = m;
+
+    if (!new_groupchats(tox)) {
+        kill_messenger(m); /* TODO messenger doesn't do everything anymore so we need to kill everything here instead */
 
         if (m_error == MESSENGER_ERROR_PORT) {
             SET_ERROR_PARAMETER(error, TOX_ERR_NEW_PORT_ALLOC);
@@ -226,38 +301,36 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
         return NULL;
     }
 
-    if (load_savedata_tox && messenger_load(m, options->savedata_data, options->savedata_length) == -1) {
+    if (load_savedata_tox && messenger_load(tox->m, options->savedata_data, options->savedata_length) == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_NEW_LOAD_BAD_FORMAT);
     } else if (load_savedata_sk) {
-        load_secret_key(m->net_crypto, options->savedata_data);
+        load_secret_key(tox->net_crypto, options->savedata_data);
         SET_ERROR_PARAMETER(error, TOX_ERR_NEW_OK);
     } else {
         SET_ERROR_PARAMETER(error, TOX_ERR_NEW_OK);
     }
 
-    return m;
+    unix_time_update();
+    tox->uptime = unix_time();
+
+    return tox;
 }
 
 void tox_kill(Tox *tox)
 {
-    Messenger *m = tox;
-    kill_groupchats(m->group_chat_object);
-    kill_messenger(m);
+    kill_groupchats(tox);
+    kill_messenger(tox->m);
     logger_kill_global();
 }
 
 size_t tox_get_savedata_size(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return messenger_size(m);
+    return messenger_size(tox);
 }
 
 void tox_get_savedata(const Tox *tox, uint8_t *data)
 {
-    if (data) {
-        const Messenger *m = tox;
-        messenger_save(m, data);
-    }
+    messenger_save(tox, data);
 }
 
 bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *public_key, TOX_ERR_BOOTSTRAP *error)
@@ -300,9 +373,8 @@ bool tox_bootstrap(Tox *tox, const char *address, uint16_t port, const uint8_t *
             continue;
         }
 
-        Messenger *m = tox;
-        onion_add_bs_path_node(m->onion_c, ip_port, public_key);
-        DHT_bootstrap(m->dht, ip_port, public_key);
+        onion_add_bs_path_node(tox->onion_c, ip_port, public_key);
+        DHT_bootstrap(tox->dht, ip_port, public_key);
         ++count;
     } while ((info = info->ai_next));
 
@@ -358,8 +430,7 @@ bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8
             continue;
         }
 
-        Messenger *m = tox;
-        add_tcp_relay(m->net_crypto, ip_port, public_key);
+        add_tcp_relay(tox->net_crypto, ip_port, public_key);
         ++count;
     } while ((info = info->ai_next));
 
@@ -376,9 +447,7 @@ bool tox_add_tcp_relay(Tox *tox, const char *address, uint16_t port, const uint8
 
 TOX_CONNECTION tox_self_get_connection_status(const Tox *tox)
 {
-    const Messenger *m = tox;
-
-    unsigned int ret = onion_connection_status(m->onion_c);
+    unsigned int ret = onion_connection_status(tox->onion_c);
 
     if (ret == 2) {
         return TOX_CONNECTION_UDP;
@@ -392,57 +461,49 @@ TOX_CONNECTION tox_self_get_connection_status(const Tox *tox)
 
 void tox_callback_self_connection_status(Tox *tox, tox_self_connection_status_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_core_connection(m, function, user_data);
+    Messenger *m = tox->m;
+    m_callback_core_connection(tox, function, user_data);
 }
 
 uint32_t tox_iteration_interval(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return messenger_run_interval(m);
+    const Messenger *m = tox->m;
+    return messenger_run_interval(tox);
 }
 
 void tox_iterate(Tox *tox)
 {
-    Messenger *m = tox;
-    do_messenger(m);
-    do_groupchats(m->group_chat_object);
+    do_tox_connections(tox->tox_conn);
+    do_messenger(tox);
+    do_groupchats(tox);
 }
 
 void tox_self_get_address(const Tox *tox, uint8_t *address)
 {
-    if (address) {
-        const Messenger *m = tox;
-        getaddress(m, address);
-    }
+    if (address)
+        getaddress(tox, address);
 }
 
 void tox_self_set_nospam(Tox *tox, uint32_t nospam)
 {
-    Messenger *m = tox;
-    set_nospam(&(m->fr), nospam);
+    set_nospam(&tox->m->fr, nospam);
 }
 
 uint32_t tox_self_get_nospam(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return get_nospam(&(m->fr));
+    return get_nospam(&tox->m->fr);
 }
 
 void tox_self_get_public_key(const Tox *tox, uint8_t *public_key)
 {
-    const Messenger *m = tox;
-
     if (public_key)
-        memcpy(public_key, m->net_crypto->self_public_key, crypto_box_PUBLICKEYBYTES);
+        memcpy(public_key, tox->net_crypto->self_public_key, crypto_box_PUBLICKEYBYTES);
 }
 
 void tox_self_get_secret_key(const Tox *tox, uint8_t *secret_key)
 {
-    const Messenger *m = tox;
-
     if (secret_key)
-        memcpy(secret_key, m->net_crypto->self_secret_key, crypto_box_SECRETKEYBYTES);
+        memcpy(secret_key, tox->net_crypto->self_secret_key, crypto_box_SECRETKEYBYTES);
 }
 
 bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, TOX_ERR_SET_INFO *error)
@@ -452,11 +513,14 @@ bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, TOX_ERR_SET
         return 0;
     }
 
-    Messenger *m = tox;
+    Messenger *m = tox->m;
 
     if (setname(m, name, length) == 0) {
-        //TODO: function to set different per group names?
-        send_name_all_groups(m->group_chat_object);
+        // --: function to set different per group names?
+        // Yes, in the new groupchats
+        send_name_all_groups(tox);
+
+
         SET_ERROR_PARAMETER(error, TOX_ERR_SET_INFO_OK);
         return 1;
     } else {
@@ -467,14 +531,14 @@ bool tox_self_set_name(Tox *tox, const uint8_t *name, size_t length, TOX_ERR_SET
 
 size_t tox_self_get_name_size(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return m_get_self_name_size(m);
+    const Messenger *m = tox->m;
+    return m_get_self_name_size(tox);
 }
 
 void tox_self_get_name(const Tox *tox, uint8_t *name)
 {
     if (name) {
-        const Messenger *m = tox;
+        const Messenger *m = tox->m;
         getself_name(m, name);
     }
 }
@@ -486,9 +550,10 @@ bool tox_self_set_status_message(Tox *tox, const uint8_t *status, size_t length,
         return 0;
     }
 
-    Messenger *m = tox;
+    Messenger *m = tox->m;
 
-    if (m_set_statusmessage(m, status, length) == 0) {
+    if (m_set_statusmessage(tox, status, length) == 0) {
+
         SET_ERROR_PARAMETER(error, TOX_ERR_SET_INFO_OK);
         return 1;
     } else {
@@ -499,62 +564,24 @@ bool tox_self_set_status_message(Tox *tox, const uint8_t *status, size_t length,
 
 size_t tox_self_get_status_message_size(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return m_get_self_statusmessage_size(m);
+    const Messenger *m = tox->m;
+    return m_get_self_statusmessage_size(tox);
 }
 
 void tox_self_get_status_message(const Tox *tox, uint8_t *status)
 {
-    if (status) {
-        const Messenger *m = tox;
-        m_copy_self_statusmessage(m, status);
-    }
+    if (status)
+        m_copy_self_statusmessage(tox, status);
 }
 
 void tox_self_set_status(Tox *tox, TOX_USER_STATUS user_status)
 {
-    Messenger *m = tox;
-    m_set_userstatus(m, user_status);
+    m_set_userstatus(tox, user_status);
 }
 
 TOX_USER_STATUS tox_self_get_status(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return m_get_self_userstatus(m);
-}
-
-static void set_friend_error(int32_t ret, TOX_ERR_FRIEND_ADD *error)
-{
-    switch (ret) {
-        case FAERR_TOOLONG:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_TOO_LONG);
-            break;
-
-        case FAERR_NOMESSAGE:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_NO_MESSAGE);
-            break;
-
-        case FAERR_OWNKEY:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_OWN_KEY);
-            break;
-
-        case FAERR_ALREADYSENT:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_ALREADY_SENT);
-            break;
-
-        case FAERR_BADCHECKSUM:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_BAD_CHECKSUM);
-            break;
-
-        case FAERR_SETNEWNOSPAM:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_SET_NEW_NOSPAM);
-            break;
-
-        case FAERR_NOMEM:
-            SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_MALLOC);
-            break;
-
-    }
+    return m_get_self_userstatus(tox);
 }
 
 uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message, size_t length,
@@ -565,15 +592,14 @@ uint32_t tox_friend_add(Tox *tox, const uint8_t *address, const uint8_t *message
         return UINT32_MAX;
     }
 
-    Messenger *m = tox;
-    int32_t ret = m_addfriend(m, address, message, length);
+    int32_t ret = m_addfriend(tox, address, message, length);
 
     if (ret >= 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_OK);
         return ret;
     }
 
-    set_friend_error(ret, error);
+    SET_ERROR_PARAMETER(error, ret);
     return UINT32_MAX;
 }
 
@@ -584,22 +610,21 @@ uint32_t tox_friend_add_norequest(Tox *tox, const uint8_t *public_key, TOX_ERR_F
         return UINT32_MAX;
     }
 
-    Messenger *m = tox;
-    int32_t ret = m_addfriend_norequest(m, public_key);
+    int32_t ret = m_addfriend_norequest(tox, public_key);
 
     if (ret >= 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_ADD_OK);
         return ret;
     }
 
-    set_friend_error(ret, error);
+    SET_ERROR_PARAMETER(error, ret);
     return UINT32_MAX;
 }
 
 bool tox_friend_delete(Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_DELETE *error)
 {
-    Messenger *m = tox;
-    int ret = m_delfriend(m, friend_number);
+
+    int ret = m_delfriend(tox, friend_number);
 
     //TODO handle if realloc fails?
     if (ret == -1) {
@@ -618,7 +643,7 @@ uint32_t tox_friend_by_public_key(const Tox *tox, const uint8_t *public_key, TOX
         return UINT32_MAX;
     }
 
-    const Messenger *m = tox;
+    const Messenger *m = tox->m;
     int32_t ret = getfriend_id(m, public_key);
 
     if (ret == -1) {
@@ -637,9 +662,7 @@ bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *
         return 0;
     }
 
-    const Messenger *m = tox;
-
-    if (get_real_pk(m, friend_number, public_key) == -1) {
+    if (get_real_pk(tox, friend_number, public_key) == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_GET_PUBLIC_KEY_FRIEND_NOT_FOUND);
         return 0;
     }
@@ -650,14 +673,12 @@ bool tox_friend_get_public_key(const Tox *tox, uint32_t friend_number, uint8_t *
 
 bool tox_friend_exists(const Tox *tox, uint32_t friend_number)
 {
-    const Messenger *m = tox;
-    return m_friend_exists(m, friend_number);
+    return m_friend_exists(tox, friend_number);
 }
 
 uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_GET_LAST_ONLINE *error)
 {
-    const Messenger *m = tox;
-    uint64_t timestamp = m_get_last_online(m, friend_number);
+    uint64_t timestamp = m_get_last_online(tox, friend_number);
 
     if (timestamp == UINT64_MAX) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_GET_LAST_ONLINE_FRIEND_NOT_FOUND)
@@ -670,14 +691,14 @@ uint64_t tox_friend_get_last_online(const Tox *tox, uint32_t friend_number, TOX_
 
 size_t tox_self_get_friend_list_size(const Tox *tox)
 {
-    const Messenger *m = tox;
+    const Messenger *m = tox->m;
     return count_friendlist(m);
 }
 
 void tox_self_get_friend_list(const Tox *tox, uint32_t *list)
 {
     if (list) {
-        const Messenger *m = tox;
+        const Messenger *m = tox->m;
         //TODO: size parameter?
         copy_friendlist(m, list, tox_self_get_friend_list_size(tox));
     }
@@ -685,8 +706,7 @@ void tox_self_get_friend_list(const Tox *tox, uint32_t *list)
 
 size_t tox_friend_get_name_size(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_QUERY *error)
 {
-    const Messenger *m = tox;
-    int ret = m_get_name_size(m, friend_number);
+    int ret = m_get_name_size(tox, friend_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
@@ -704,7 +724,7 @@ bool tox_friend_get_name(const Tox *tox, uint32_t friend_number, uint8_t *name, 
         return 0;
     }
 
-    const Messenger *m = tox;
+    const Messenger *m = tox->m;
     int ret = getname(m, friend_number, name);
 
     if (ret == -1) {
@@ -718,14 +738,12 @@ bool tox_friend_get_name(const Tox *tox, uint32_t friend_number, uint8_t *name, 
 
 void tox_callback_friend_name(Tox *tox, tox_friend_name_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_namechange(m, function, user_data);
+    m_callback_namechange(tox, function, user_data);
 }
 
 size_t tox_friend_get_status_message_size(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_QUERY *error)
 {
-    const Messenger *m = tox;
-    int ret = m_get_statusmessage_size(m, friend_number);
+    int ret = m_get_statusmessage_size(tox, friend_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
@@ -744,9 +762,8 @@ bool tox_friend_get_status_message(const Tox *tox, uint32_t friend_number, uint8
         return 0;
     }
 
-    const Messenger *m = tox;
     //TODO: size parameter?
-    int ret = m_copy_statusmessage(m, friend_number, message, m_get_statusmessage_size(m, friend_number));
+    int ret = m_copy_statusmessage(tox, friend_number, message, m_get_statusmessage_size(tox, friend_number));
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
@@ -759,15 +776,12 @@ bool tox_friend_get_status_message(const Tox *tox, uint32_t friend_number, uint8
 
 void tox_callback_friend_status_message(Tox *tox, tox_friend_status_message_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_statusmessage(m, function, user_data);
+    m_callback_statusmessage(tox, function, user_data);
 }
 
 TOX_USER_STATUS tox_friend_get_status(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_QUERY *error)
 {
-    const Messenger *m = tox;
-
-    int ret = m_get_userstatus(m, friend_number);
+    int ret = m_get_userstatus(tox, friend_number);
 
     if (ret == USERSTATUS_INVALID) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
@@ -780,15 +794,12 @@ TOX_USER_STATUS tox_friend_get_status(const Tox *tox, uint32_t friend_number, TO
 
 void tox_callback_friend_status(Tox *tox, tox_friend_status_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_userstatus(m, function, user_data);
+    m_callback_userstatus(tox, function, user_data);
 }
 
 TOX_CONNECTION tox_friend_get_connection_status(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_QUERY *error)
 {
-    const Messenger *m = tox;
-
-    int ret = m_get_friend_connectionstatus(m, friend_number);
+    int ret = m_get_friend_connectionstatus(tox, friend_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
@@ -801,14 +812,12 @@ TOX_CONNECTION tox_friend_get_connection_status(const Tox *tox, uint32_t friend_
 
 void tox_callback_friend_connection_status(Tox *tox, tox_friend_connection_status_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_connectionstatus(m, function, user_data);
+    m_callback_connectionstatus(tox, function, user_data);
 }
 
 bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEND_QUERY *error)
 {
-    const Messenger *m = tox;
-    int ret = m_get_istyping(m, friend_number);
+    int ret = m_get_istyping(tox, friend_number);
 
     if (ret == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_QUERY_FRIEND_NOT_FOUND);
@@ -821,15 +830,12 @@ bool tox_friend_get_typing(const Tox *tox, uint32_t friend_number, TOX_ERR_FRIEN
 
 void tox_callback_friend_typing(Tox *tox, tox_friend_typing_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_typingchange(m, function, user_data);
+    m_callback_typingchange(tox, function, user_data);
 }
 
 bool tox_self_set_typing(Tox *tox, uint32_t friend_number, bool is_typing, TOX_ERR_SET_TYPING *error)
 {
-    Messenger *m = tox;
-
-    if (m_set_usertyping(m, friend_number, is_typing) == -1) {
+    if (m_set_usertyping(tox, friend_number, is_typing) == -1) {
         SET_ERROR_PARAMETER(error, TOX_ERR_SET_TYPING_FRIEND_NOT_FOUND);
         return 0;
     }
@@ -880,28 +886,26 @@ uint32_t tox_friend_send_message(Tox *tox, uint32_t friend_number, TOX_MESSAGE_T
         return 0;
     }
 
-    Messenger *m = tox;
     uint32_t message_id = 0;
-    set_message_error(m_send_message_generic(m, friend_number, type, message, length, &message_id), error);
+    set_message_error(m_send_message_generic(tox, friend_number, type, message, length, &message_id), error);
+
+
     return message_id;
 }
 
 void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_read_receipt(m, function, user_data);
+    m_callback_read_receipt(tox, function, user_data);
 }
 
 void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_friendrequest(m, function, user_data);
+    m_callback_friendrequest(tox, function, user_data);
 }
 
 void tox_callback_friend_message(Tox *tox, tox_friend_message_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    m_callback_friendmessage(m, function, user_data);
+    m_callback_friendmessage(tox, function, user_data);
 }
 
 bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length)
@@ -917,8 +921,7 @@ bool tox_hash(uint8_t *hash, const uint8_t *data, size_t length)
 bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, TOX_FILE_CONTROL control,
                       TOX_ERR_FILE_CONTROL *error)
 {
-    Messenger *m = tox;
-    int ret = file_control(m, friend_number, file_number, control);
+    int ret = file_control(tox, friend_number, file_number, control);
 
     if (ret == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FILE_CONTROL_OK);
@@ -966,8 +969,7 @@ bool tox_file_control(Tox *tox, uint32_t friend_number, uint32_t file_number, TO
 bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
                    TOX_ERR_FILE_SEEK *error)
 {
-    Messenger *m = tox;
-    int ret = file_seek(m, friend_number, file_number, position);
+    int ret = file_seek(tox, friend_number, file_number, position);
 
     if (ret == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEEK_OK);
@@ -1007,8 +1009,7 @@ bool tox_file_seek(Tox *tox, uint32_t friend_number, uint32_t file_number, uint6
 
 void tox_callback_file_recv_control(Tox *tox, tox_file_recv_control_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    callback_file_control(m, function, user_data);
+    callback_file_control(tox, function, user_data);
 }
 
 bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_number, uint8_t *file_id,
@@ -1019,8 +1020,7 @@ bool tox_file_get_file_id(const Tox *tox, uint32_t friend_number, uint32_t file_
         return 0;
     }
 
-    const Messenger *m = tox;
-    int ret = file_get_id(m, friend_number, file_number, file_id);
+    int ret = file_get_id(tox, friend_number, file_number, file_id);
 
     if (ret == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FILE_GET_OK);
@@ -1050,8 +1050,7 @@ uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t
         file_id = f_id;
     }
 
-    Messenger *m = tox;
-    long int file_num = new_filesender(m, friend_number, kind, file_size, file_id, filename, filename_length);
+    long int file_num = new_filesender(tox, friend_number, kind, file_size, file_id, filename, filename_length);
 
     if (file_num >= 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_OK);
@@ -1083,8 +1082,7 @@ uint32_t tox_file_send(Tox *tox, uint32_t friend_number, uint32_t kind, uint64_t
 bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, const uint8_t *data,
                          size_t length, TOX_ERR_FILE_SEND_CHUNK *error)
 {
-    Messenger *m = tox;
-    int ret = file_data(m, friend_number, file_number, position, data, length);
+    int ret = file_data(tox, friend_number, file_number, position, data, length);
 
     if (ret == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FILE_SEND_CHUNK_OK);
@@ -1127,20 +1125,17 @@ bool tox_file_send_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number,
 
 void tox_callback_file_chunk_request(Tox *tox, tox_file_chunk_request_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    callback_file_reqchunk(m, function, user_data);
+    callback_file_reqchunk(tox, function, user_data);
 }
 
 void tox_callback_file_recv(Tox *tox, tox_file_recv_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    callback_file_sendrequest(m, function, user_data);
+    callback_file_sendrequest(tox, function, user_data);
 }
 
 void tox_callback_file_recv_chunk(Tox *tox, tox_file_recv_chunk_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    callback_file_data(m, function, user_data);
+    callback_file_data(tox, function, user_data);
 }
 
 static void set_custom_packet_error(int ret, TOX_ERR_FRIEND_CUSTOM_PACKET *error)
@@ -1180,8 +1175,6 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
         return 0;
     }
 
-    Messenger *m = tox;
-
     if (length == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_EMPTY);
         return 0;
@@ -1192,7 +1185,7 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
         return 0;
     }
 
-    int ret = send_custom_lossy_packet(m, friend_number, data, length);
+    int ret = send_custom_lossy_packet(tox, friend_number, data, length);
 
     set_custom_packet_error(ret, error);
 
@@ -1205,8 +1198,7 @@ bool tox_friend_send_lossy_packet(Tox *tox, uint32_t friend_number, const uint8_
 
 void tox_callback_friend_lossy_packet(Tox *tox, tox_friend_lossy_packet_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    custom_lossy_packet_registerhandler(m, function, user_data);
+    custom_lossy_packet_registerhandler(tox, function, user_data);
 }
 
 bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uint8_t *data, size_t length,
@@ -1217,14 +1209,12 @@ bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uin
         return 0;
     }
 
-    Messenger *m = tox;
-
     if (length == 0) {
         SET_ERROR_PARAMETER(error, TOX_ERR_FRIEND_CUSTOM_PACKET_EMPTY);
         return 0;
     }
 
-    int ret = send_custom_lossless_packet(m, friend_number, data, length);
+    int ret = send_custom_lossless_packet(tox, friend_number, data, length);
 
     set_custom_packet_error(ret, error);
 
@@ -1237,22 +1227,18 @@ bool tox_friend_send_lossless_packet(Tox *tox, uint32_t friend_number, const uin
 
 void tox_callback_friend_lossless_packet(Tox *tox, tox_friend_lossless_packet_cb *function, void *user_data)
 {
-    Messenger *m = tox;
-    custom_lossless_packet_registerhandler(m, function, user_data);
+    custom_lossless_packet_registerhandler(tox, function, user_data);
 }
 
 void tox_self_get_dht_id(const Tox *tox, uint8_t *dht_id)
 {
-    if (dht_id) {
-        const Messenger *m = tox;
-        memcpy(dht_id , m->dht->self_public_key, crypto_box_PUBLICKEYBYTES);
-    }
+    if (dht_id)
+        memcpy(dht_id , tox->dht->self_public_key, crypto_box_PUBLICKEYBYTES);
 }
 
 uint16_t tox_self_get_udp_port(const Tox *tox, TOX_ERR_GET_PORT *error)
 {
-    const Messenger *m = tox;
-    uint16_t port = htons(m->net->port);
+    uint16_t port = htons(tox->net->port);
 
     if (port) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GET_PORT_OK);
@@ -1265,7 +1251,7 @@ uint16_t tox_self_get_udp_port(const Tox *tox, TOX_ERR_GET_PORT *error)
 
 uint16_t tox_self_get_tcp_port(const Tox *tox, TOX_ERR_GET_PORT *error)
 {
-    const Messenger *m = tox;
+    const Messenger *m = tox->m;
 
     if (m->tcp_server) {
         SET_ERROR_PARAMETER(error, TOX_ERR_GET_PORT_OK);

--- a/toxcore/tox_connection.c
+++ b/toxcore/tox_connection.c
@@ -25,7 +25,7 @@
 #include "config.h"
 #endif
 
-#include "friend_connection.h"
+#include "tox_connection.h"
 #include "util.h"
 
 /* return 1 if the toxconn_id is not valid.

--- a/toxcore/tox_connection.c
+++ b/toxcore/tox_connection.c
@@ -130,7 +130,7 @@ static Tox_Conn *get_conn(const Tox_Connections *tox_conns, int toxconn_id)
 /* return toxconn_id corresponding to the real public key on success.
  * return -1 on failure.
  */
-int gettox_conn_id_pk(Tox_Connections *tox_conns, const uint8_t *real_pk)
+int toxconn_get_id_from_pk(Tox_Connections *tox_conns, const uint8_t *real_pk)
 {
     uint32_t i;
 
@@ -453,7 +453,7 @@ static int handle_lossy_packet(void *object, int number, const uint8_t *data, ui
 static int handle_new_connections(void *object, New_Connection *n_c)
 {
     Tox_Connections *tox_conns = object;
-    int toxconn_id = gettox_conn_id_pk(tox_conns, n_c->public_key);
+    int toxconn_id = toxconn_get_id_from_pk(tox_conns, n_c->public_key);
     Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
     if (tox_con) {
@@ -543,7 +543,7 @@ static int send_ping(const Tox_Connections *tox_conns, int toxconn_id)
  * return 0 on success.
  * return -1 on failure.
  */
-int tox_connection_lock(Tox_Connections *tox_conns, int toxconn_id)
+int toxconn_inc_connection_lock(Tox_Connections *tox_conns, int toxconn_id)
 {
     Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
@@ -558,7 +558,7 @@ int tox_connection_lock(Tox_Connections *tox_conns, int toxconn_id)
  * return TOXCONN_STATUS_CONNECTING if the peer isn't connected.
  * return TOXCONN_STATUS_NONE on failure.
  */
-unsigned int tox_conn_is_connected(Tox_Connections *tox_conns, int toxconn_id)
+unsigned int toxconn_is_connected(Tox_Connections *tox_conns, int toxconn_id)
 {
     Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
@@ -573,7 +573,7 @@ unsigned int tox_conn_is_connected(Tox_Connections *tox_conns, int toxconn_id)
  * return 0 on success.
  * return -1 on failure.
  */
-int tox_conn_get_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Tox_Connections *tox_conns, int toxconn_id)
+int toxconn_get_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Tox_Connections *tox_conns, int toxconn_id)
 {
     Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
@@ -601,7 +601,7 @@ void set_dht_temp_pk(Tox_Connections *tox_conns, int toxconn_id, const uint8_t *
  * return 0 on success.
  * return -1 on failure
  */
-int tox_conn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned int index,
+int toxconn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned int index,
                                 int (*status_callback)(void *object, int id, uint8_t status),
                                 int (*data_callback)(void *object, int id, uint8_t *data, uint16_t length),
                                 int (*lossy_data_callback)(void *object, int id, const uint8_t *data, uint16_t length),
@@ -634,7 +634,7 @@ int tox_conn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned 
  * return crypt_connection_id on success.
  * return -1 on failure.
  */
-int tox_conn_crypt_connection_id(Tox_Connections *tox_conns, int toxconn_id)
+int toxconn_crypt_connection_id(Tox_Connections *tox_conns, int toxconn_id)
 {
     Tox_Conn *tox_con = get_conn(tox_conns, toxconn_id);
 
@@ -652,7 +652,7 @@ int tox_conn_crypt_connection_id(Tox_Connections *tox_conns, int toxconn_id)
  */
 int new_tox_conn(Tox_Connections *tox_conns, const uint8_t *real_public_key)
 {
-    int toxconn_id = gettox_conn_id_pk(tox_conns, real_public_key);
+    int toxconn_id = toxconn_get_id_from_pk(tox_conns, real_public_key);
 
     if (toxconn_id != -1) {
         ++tox_conns->conns[toxconn_id].lock_count;
@@ -714,7 +714,7 @@ int kill_tox_conn(Tox_Connections *tox_conns, int toxconn_id)
  *
  * This function will be called every time any connection request packet is received.
  */
-void set_tox_conn_request_callback(Tox_Connections *tox_conns,
+void set_toxconn_request_callback(Tox_Connections *tox_conns,
                                    int (*toxconn_request_callback)(void *, const uint8_t *, const uint8_t *, uint16_t),
                                    void *object)
 {
@@ -729,7 +729,7 @@ void set_tox_conn_request_callback(Tox_Connections *tox_conns,
  *  return  0 if it sent the friend request directly to the friend.
  *  return the number of peers it was routed through if it did not send it directly.
  */
-int send_tox_conn_request_pkt(Tox_Connections *tox_conns, int toxconn_id, uint32_t nospam_num, const uint8_t *data,
+int send_toxconn_request_pkt(Tox_Connections *tox_conns, int toxconn_id, uint32_t nospam_num, const uint8_t *data,
                                uint16_t length)
 {
     if (1 + sizeof(nospam_num) + length > ONION_CLIENT_MAX_DATA_SIZE || length == 0)

--- a/toxcore/tox_connection.h
+++ b/toxcore/tox_connection.h
@@ -1,4 +1,4 @@
-/* friend_connection.h
+/* tox_connection.h
  *
  * Connection to tox instances.
  *

--- a/toxcore/tox_connection.h
+++ b/toxcore/tox_connection.h
@@ -101,7 +101,7 @@ typedef struct {
 } Tox_Conn;
 
 
-typedef struct {
+typedef struct Tox_Connections{
     Net_Crypto *net_crypto;
     DHT *dht;
     Onion_Client *onion_c;
@@ -118,27 +118,27 @@ typedef struct {
 /* return toxconn_id corresponding to the real public key on success.
  * return -1 on failure.
  */
-int gettox_conn_id_pk(Tox_Connections *tox_conns, const uint8_t *real_pk);
+int toxconn_get_id_from_pk(Tox_Connections *tox_conns, const uint8_t *real_pk);
 
 /* Increases lock_count for the connection with toxconn_id by 1.
  *
  * return 0 on success.
  * return -1 on failure.
  */
-int tox_connection_lock(Tox_Connections *tox_conns, int toxconn_id);
+int toxconn_inc_connection_lock(Tox_Connections *tox_conns, int toxconn_id);
 
 /* return TOXCONN_STATUS_CONNECTED if the peer is connected.
  * return TOXCONN_STATUS_CONNECTING if the peer isn't connected.
  * return TOXCONN_STATUS_NONE on failure.
  */
-unsigned int tox_conn_is_connected(Tox_Connections *tox_conns, int toxconn_id);
+unsigned int toxconn_is_connected(Tox_Connections *tox_conns, int toxconn_id);
 
 /* Copy public keys associated to toxconn_id.
  *
  * return 0 on success.
  * return -1 on failure.
  */
-int tox_conn_get_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Tox_Connections *tox_conns, int toxconn_id);
+int toxconn_get_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Tox_Connections *tox_conns, int toxconn_id);
 
 /* Set temp dht key for connection.
  */
@@ -157,7 +157,7 @@ int toxconn_add_tcp_relay(Tox_Connections *tox_conns, int toxconn_id, IP_Port ip
  * return 0 on success.
  * return -1 on failure
  */
-int tox_conn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned int index,
+int toxconn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned int index,
                                 int (*status_callback)(void *object, int id, uint8_t status),
                                 int (*data_callback)(void *object, int id, uint8_t *data, uint16_t length),
                                 int (*lossy_data_callback)(void *object, int id, const uint8_t *data, uint16_t length),
@@ -168,7 +168,7 @@ int tox_conn_set_callbacks(Tox_Connections *tox_conns, int toxconn_id, unsigned 
  * return crypt_connection_id on success.
  * return -1 on failure.
  */
-int tox_conn_crypt_connection_id(Tox_Connections *tox_conns, int toxconn_id);
+int toxconn_crypt_connection_id(Tox_Connections *tox_conns, int toxconn_id);
 
 /* Create a new tox connection.
  * If one to that real public key already exists, increase lock count and return it.
@@ -191,14 +191,14 @@ int kill_tox_conn(Tox_Connections *tox_conns, int toxconn_id);
  *  return  0 if it sent the connection request was received directly.
  *  return the number of peers it was routed through if it did not send it directly.
  */
-int send_tox_conn_request_pkt(Tox_Connections *tox_conns, int toxconn_id, uint32_t nospam_num, const uint8_t *data,
+int send_toxconn_request_pkt(Tox_Connections *tox_conns, int toxconn_id, uint32_t nospam_num, const uint8_t *data,
                                uint16_t length);
 
 /* Set connection request callback.
  *
  * This function will be called every time a connection request is received.
  */
-void set_tox_conn_request_callback(Tox_Connections *tox_conns,
+void set_toxconn_request_callback(Tox_Connections *tox_conns,
                                    int (*toxconn_request_callback)(void *, const uint8_t *,const uint8_t *, uint16_t),
                                    void *object);
 

--- a/toxcore/tox_old_code.h
+++ b/toxcore/tox_old_code.h
@@ -6,33 +6,30 @@
  *
  * data of length is what needs to be passed to join_groupchat().
  */
-void tox_callback_group_invite(Tox *tox, void (*function)(Messenger *tox, int32_t, uint8_t, const uint8_t *, uint16_t,
+void tox_callback_group_invite(Tox *tox, void (*function)(Tox *tox, int32_t, uint8_t, const uint8_t *, uint16_t,
                                void *), void *userdata)
 {
-    Messenger *m = tox;
-    g_callback_group_invite(m->group_chat_object, function, userdata);
+    g_callback_group_invite(tox, function, userdata);
 }
 
 /* Set the callback for group messages.
  *
  *  Function(Tox *tox, int groupnumber, int peernumber, uint8_t * message, uint16_t length, void *userdata)
  */
-void tox_callback_group_message(Tox *tox, void (*function)(Messenger *tox, int, int, const uint8_t *, uint16_t, void *),
+void tox_callback_group_message(Tox *tox, void (*function)(Tox *tox, int, int, const uint8_t *, uint16_t, void *),
                                 void *userdata)
 {
-    Messenger *m = tox;
-    g_callback_group_message(m->group_chat_object, function, userdata);
+    g_callback_group_message(tox, function, userdata);
 }
 
 /* Set the callback for group actions.
  *
  *  Function(Tox *tox, int groupnumber, int peernumber, uint8_t * action, uint16_t length, void *userdata)
  */
-void tox_callback_group_action(Tox *tox, void (*function)(Messenger *tox, int, int, const uint8_t *, uint16_t, void *),
+void tox_callback_group_action(Tox *tox, void (*function)(Tox *tox, int, int, const uint8_t *, uint16_t, void *),
                                void *userdata)
 {
-    Messenger *m = tox;
-    g_callback_group_action(m->group_chat_object, function, userdata);
+    g_callback_group_action(tox, function, userdata);
 }
 
 /* Set callback function for title changes.
@@ -40,11 +37,10 @@ void tox_callback_group_action(Tox *tox, void (*function)(Messenger *tox, int, i
  * Function(Tox *tox, int groupnumber, int peernumber, uint8_t * title, uint8_t length, void *userdata)
  * if peernumber == -1, then author is unknown (e.g. initial joining the group)
  */
-void tox_callback_group_title(Tox *tox, void (*function)(Messenger *tox, int, int, const uint8_t *, uint8_t,
+void tox_callback_group_title(Tox *tox, void (*function)(Tox *tox, int, int, const uint8_t *, uint8_t,
                               void *), void *userdata)
 {
-    Messenger *m = tox;
-    g_callback_group_title(m->group_chat_object, function, userdata);
+    g_callback_group_title(tox, function, userdata);
 }
 
 /* Set callback function for peer name list changes.
@@ -54,8 +50,7 @@ void tox_callback_group_title(Tox *tox, void (*function)(Messenger *tox, int, in
  */
 void tox_callback_group_namelist_change(Tox *tox, void (*function)(Tox *tox, int, int, uint8_t, void *), void *userdata)
 {
-    Messenger *m = tox;
-    g_callback_group_namelistchange(m->group_chat_object, function, userdata);
+    g_callback_group_namelistchange(tox, function, userdata);
 }
 
 /* Creates a new groupchat and puts it in the chats array.
@@ -65,8 +60,7 @@ void tox_callback_group_namelist_change(Tox *tox, void (*function)(Tox *tox, int
  */
 int tox_add_groupchat(Tox *tox)
 {
-    Messenger *m = tox;
-    return add_groupchat(m->group_chat_object, GROUPCHAT_TYPE_TEXT);
+    return add_groupchat(tox, GROUPCHAT_TYPE_TEXT);
 }
 
 /* Delete a groupchat from the chats array.
@@ -76,8 +70,7 @@ int tox_add_groupchat(Tox *tox)
  */
 int tox_del_groupchat(Tox *tox, int groupnumber)
 {
-    Messenger *m = tox;
-    return del_groupchat(m->group_chat_object, groupnumber);
+    return del_groupchat(tox, groupnumber);
 }
 
 /* Copy the name of peernumber who is in groupnumber to name.
@@ -88,8 +81,7 @@ int tox_del_groupchat(Tox *tox, int groupnumber)
  */
 int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t *name)
 {
-    const Messenger *m = tox;
-    return group_peername(m->group_chat_object, groupnumber, peernumber, name);
+    return group_peername(tox, groupnumber, peernumber, name);
 }
 
 /* Copy the public key of peernumber who is in groupnumber to public_key.
@@ -100,8 +92,7 @@ int tox_group_peername(const Tox *tox, int groupnumber, int peernumber, uint8_t 
  */
 int tox_group_peer_pubkey(const Tox *tox, int groupnumber, int peernumber, uint8_t *public_key)
 {
-    const Messenger *m = tox;
-    return group_peer_pubkey(m->group_chat_object, groupnumber, peernumber, public_key);
+    return group_peer_pubkey(tox, groupnumber, peernumber, public_key);
 }
 
 /* invite friendnumber to groupnumber
@@ -110,8 +101,7 @@ int tox_group_peer_pubkey(const Tox *tox, int groupnumber, int peernumber, uint8
  */
 int tox_invite_friend(Tox *tox, int32_t friendnumber, int groupnumber)
 {
-    Messenger *m = tox;
-    return invite_friend(m->group_chat_object, friendnumber, groupnumber);
+    return invite_friend(tox, friendnumber, groupnumber);
 }
 
 /* Join a group (you need to have been invited first.) using data of length obtained
@@ -122,8 +112,7 @@ int tox_invite_friend(Tox *tox, int32_t friendnumber, int groupnumber)
  */
 int tox_join_groupchat(Tox *tox, int32_t friendnumber, const uint8_t *data, uint16_t length)
 {
-    Messenger *m = tox;
-    return join_groupchat(m->group_chat_object, friendnumber, GROUPCHAT_TYPE_TEXT, data, length);
+    return join_groupchat(tox, friendnumber, GROUPCHAT_TYPE_TEXT, data, length);
 }
 
 /* send a group message
@@ -132,8 +121,7 @@ int tox_join_groupchat(Tox *tox, int32_t friendnumber, const uint8_t *data, uint
  */
 int tox_group_message_send(Tox *tox, int groupnumber, const uint8_t *message, uint16_t length)
 {
-    Messenger *m = tox;
-    return group_message_send(m->group_chat_object, groupnumber, message, length);
+    return group_message_send(tox, groupnumber, message, length);
 }
 
 /* send a group action
@@ -142,8 +130,7 @@ int tox_group_message_send(Tox *tox, int groupnumber, const uint8_t *message, ui
  */
 int tox_group_action_send(Tox *tox, int groupnumber, const uint8_t *action, uint16_t length)
 {
-    Messenger *m = tox;
-    return group_action_send(m->group_chat_object, groupnumber, action, length);
+    return group_action_send(tox, groupnumber, action, length);
 }
 
 /* set the group's title, limited to MAX_NAME_LENGTH
@@ -152,8 +139,7 @@ int tox_group_action_send(Tox *tox, int groupnumber, const uint8_t *action, uint
  */
 int tox_group_set_title(Tox *tox, int groupnumber, const uint8_t *title, uint8_t length)
 {
-    Messenger *m = tox;
-    return group_title_send(m->group_chat_object, groupnumber, title, length);
+    return group_title_send(tox, groupnumber, title, length);
 }
 
 /* Get group title from groupnumber and put it in title.
@@ -164,8 +150,7 @@ int tox_group_set_title(Tox *tox, int groupnumber, const uint8_t *title, uint8_t
  */
 int tox_group_get_title(Tox *tox, int groupnumber, uint8_t *title, uint32_t max_length)
 {
-    Messenger *m = tox;
-    return group_title_get(m->group_chat_object, groupnumber, title, max_length);
+    return group_title_get(tox, groupnumber, title, max_length);
 }
 
 /* Check if the current peernumber corresponds to ours.
@@ -175,8 +160,7 @@ int tox_group_get_title(Tox *tox, int groupnumber, uint8_t *title, uint32_t max_
  */
 unsigned int tox_group_peernumber_is_ours(const Tox *tox, int groupnumber, int peernumber)
 {
-    const Messenger *m = tox;
-    return group_peernumber_is_ours(m->group_chat_object, groupnumber, peernumber);
+    return group_peernumber_is_ours(tox, groupnumber, peernumber);
 }
 
 /* Return the number of peers in the group chat on success.
@@ -184,8 +168,7 @@ unsigned int tox_group_peernumber_is_ours(const Tox *tox, int groupnumber, int p
  */
 int tox_group_number_peers(const Tox *tox, int groupnumber)
 {
-    const Messenger *m = tox;
-    return group_number_peers(m->group_chat_object, groupnumber);
+    return group_number_peers(tox, groupnumber);
 }
 
 /* List all the peers in the group chat.
@@ -201,8 +184,7 @@ int tox_group_number_peers(const Tox *tox, int groupnumber)
 int tox_group_get_names(const Tox *tox, int groupnumber, uint8_t names[][TOX_MAX_NAME_LENGTH], uint16_t lengths[],
                         uint16_t length)
 {
-    const Messenger *m = tox;
-    return group_names(m->group_chat_object, groupnumber, names, lengths, length);
+    return group_names(tox, groupnumber, names, lengths, length);
 }
 
 /* Return the number of chats in the instance m.
@@ -210,8 +192,7 @@ int tox_group_get_names(const Tox *tox, int groupnumber, uint8_t names[][TOX_MAX
  * for copy_chatlist. */
 uint32_t tox_count_chatlist(const Tox *tox)
 {
-    const Messenger *m = tox;
-    return count_chatlist(m->group_chat_object);
+    return count_chatlist(tox);
 }
 
 /* Copy a list of valid chat IDs into the array out_list.
@@ -221,8 +202,7 @@ uint32_t tox_count_chatlist(const Tox *tox)
  * of out_list will be truncated to list_size. */
 uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size)
 {
-    const Messenger *m = tox;
-    return copy_chatlist(m->group_chat_object, out_list, list_size);
+    return copy_chatlist(tox, out_list, list_size);
 }
 
 /* return the type of groupchat (TOX_GROUPCHAT_TYPE_) that groupnumber is.
@@ -232,6 +212,5 @@ uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size)
  */
 int tox_group_get_type(const Tox *tox, int groupnumber)
 {
-    const Messenger *m = tox;
-    return group_get_type(m->group_chat_object, groupnumber);
+    return group_get_type(tox, groupnumber);
 }


### PR DESCRIPTION
Oh, boy... I knew this commit was going to be huge, but I didn't know how big.
There's no way to make this smaller, without breaking more stuff, as it is, it
only compiles if you
./configure --disable-tests --disable-testing --disable-av ...

For the most of it, It's a lot of sane renames, and close consideration. With
the notable exception of group.{c,h} & tox_old_code.h. Both of which I decided
to do bulk replacements of *Group_Chats to *Tox, and linking the code on line 1
of the function to avoid changing a lot of lines with important code. I decided
to do it this way because the global plan for toxcore is to replace the current
groupchats with something better. So this change was quick, instead of detailed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/19)
<!-- Reviewable:end -->
