### PR TITLE
8. Stateless

### DIFF
--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -443,7 +443,7 @@ START_TEST(test_few_clients)
 
     uint32_t to_compare = 974536;
     connected_t1 = 0;
-    tox_callback_self_connection_status(tox1, tox_connection_status, &to_compare);
+    tox_callback_self_connection_status(tox1, tox_connection_status);
     tox_callback_friend_request(tox2, accept_friend_request, &to_compare);
     uint8_t address[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox2, address);
@@ -453,9 +453,9 @@ START_TEST(test_few_clients)
     uint8_t off = 1;
 
     while (1) {
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (tox_self_get_connection_status(tox1) && tox_self_get_connection_status(tox2)
                 && tox_self_get_connection_status(tox3)) {
@@ -487,9 +487,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         messages_received = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (messages_received)
             break;
@@ -516,9 +516,9 @@ START_TEST(test_few_clients)
     off = 1;
 
     while (1) {
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (tox_self_get_connection_status(tox1) && tox_self_get_connection_status(tox2)
                 && tox_self_get_connection_status(tox3)) {
@@ -544,9 +544,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         name_changes = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (name_changes)
             break;
@@ -565,9 +565,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         status_m_changes = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (status_m_changes)
             break;
@@ -587,9 +587,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         typing_changes = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
 
         if (typing_changes == 2)
@@ -605,9 +605,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         typing_changes = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (typing_changes == 1)
             break;
@@ -632,9 +632,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         custom_packet = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (custom_packet == 1)
             break;
@@ -654,9 +654,9 @@ START_TEST(test_few_clients)
 
     while (1) {
         custom_packet = 0;
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (custom_packet == 1)
             break;
@@ -690,9 +690,9 @@ START_TEST(test_few_clients)
     ck_assert_msg(gfierr == TOX_ERR_FILE_GET_OK, "wrong error");
 
     while (1) {
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (file_sending_done) {
             if (sendf_ok && file_recv && totalf_size == file_size && size_recv == file_size && sending_pos == size_recv
@@ -742,9 +742,9 @@ START_TEST(test_few_clients)
     m_send_reached = 0;
 
     while (1) {
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (file_sending_done) {
             if (sendf_ok && file_recv && m_send_reached && totalf_size == file_size && size_recv == max_sending
@@ -791,9 +791,9 @@ START_TEST(test_few_clients)
 
 
     while (1) {
-        tox_iterate(tox1);
-        tox_iterate(tox2);
-        tox_iterate(tox3);
+        tox_iterate(tox1, &to_compare);
+        tox_iterate(tox2, &to_compare);
+        tox_iterate(tox3, &to_compare);
 
         if (file_sending_done) {
             if (sendf_ok && file_recv && totalf_size == file_size && size_recv == file_size && sending_pos == size_recv
@@ -904,7 +904,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_TOXES; ++i) {
-            tox_iterate(toxes[i]);
+            tox_iterate(toxes[i], NULL);
         }
 
         c_sleep(50);
@@ -1002,7 +1002,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            tox_iterate(toxes[i]);
+            tox_iterate(toxes[i], NULL);
         }
 
         c_sleep(50);
@@ -1098,7 +1098,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            tox_iterate(toxes[i]);
+            tox_iterate(toxes[i], NULL);
         }
 
         c_sleep(30);
@@ -1206,7 +1206,7 @@ group_test_restart:
             break;
 
         for (i = 0; i < NUM_GROUP_TOX; ++i) {
-            tox_iterate(toxes[i]);
+            tox_iterate(toxes[i], NULL);
         }
 
         c_sleep(25);
@@ -1224,7 +1224,7 @@ group_test_restart:
 
     while (1) {
         for (i = 0; i < NUM_GROUP_TOX; ++i) {
-            tox_iterate(toxes[i]);
+            tox_iterate(toxes[i], NULL);
         }
 
         if (!invite_counter) {
@@ -1287,7 +1287,7 @@ group_test_restart:
 
     for (j = 0; j < 20; ++j) {
         for (i = 0; i < NUM_GROUP_TOX; ++i) {
-            tox_iterate(toxes[i]);
+            tox_iterate(toxes[i], NULL);
         }
 
         c_sleep(25);
@@ -1301,7 +1301,7 @@ group_test_restart:
 
         for (j = 0; j < 10; ++j) {
             for (i = 0; i < NUM_GROUP_TOX; ++i) {
-                tox_iterate(toxes[i]);
+                tox_iterate(toxes[i], NULL);
             }
 
             c_sleep(50);

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -124,9 +124,9 @@ void t_accept_friend_request_cb(Tox *m, const uint8_t *public_key, const uint8_t
  */
 int iterate_tox(Tox *bootstrap, Tox *Alice, Tox *Bob)
 {
-    tox_iterate(bootstrap);
-    tox_iterate(Alice);
-    tox_iterate(Bob);
+    tox_iterate(bootstrap, NULL);
+    tox_iterate(Alice, NULL);
+    tox_iterate(Bob, NULL);
 
     return MIN(tox_iteration_interval(Alice), tox_iteration_interval(Bob));
 }

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -248,11 +248,11 @@ START_TEST(test_AV_three_calls)
     uint8_t off = 1;
 
     while (1) {
-        tox_iterate(bootstrap);
-        tox_iterate(Alice);
-        tox_iterate(Bobs[0]);
-        tox_iterate(Bobs[1]);
-        tox_iterate(Bobs[2]);
+        tox_iterate(bootstrap, NULL);
+        tox_iterate(Alice, NULL);
+        tox_iterate(Bobs[0], NULL);
+        tox_iterate(Bobs[1], NULL);
+        tox_iterate(Bobs[2], NULL);
 
         if (tox_self_get_connection_status(bootstrap) &&
                 tox_self_get_connection_status(Alice) &&
@@ -313,10 +313,10 @@ START_TEST(test_AV_three_calls)
     time_t start_time = time(NULL);
 
     while (time(NULL) - start_time < 5) {
-        tox_iterate(Alice);
-        tox_iterate(Bobs[0]);
-        tox_iterate(Bobs[1]);
-        tox_iterate(Bobs[2]);
+        tox_iterate(Alice, NULL);
+        tox_iterate(Bobs[0], NULL);
+        tox_iterate(Bobs[1], NULL);
+        tox_iterate(Bobs[2], NULL);
         c_sleep(20);
     }
 

--- a/other/apidsl/README.md
+++ b/other/apidsl/README.md
@@ -18,14 +18,16 @@ If you want to do it quickly and you don't have time for anything other than cop
 
 Command to run from ``toxcore`` directory (quick way, involves using curl):
 ```bash
-rm toxcore/tox.h && \
-( curl -X POST --data-binary @- https://apidsl.herokuapp.com/apidsl < ./other/apidsl/tox.in.h > ./toxcore/tox.h ) && \
-astyle --options=./other/astyle/astylerc ./toxcore/tox.h
-```
-
-When formatting will be complete, you should see output like:
-```
-Formatted  ./toxcore/tox.h
+# For tox.h:
+curl -X POST --data-binary @- https://apidsl.herokuapp.com/apidsl \
+  < other/apidsl/tox.in.h \
+  | astyle --options=other/astyle/astylerc \
+  > toxcore/tox.h
+# For toxav.h:
+curl -X POST --data-binary @- https://apidsl.herokuapp.com/apidsl \
+  < other/apidsl/toxav.in.h \
+  | astyle --options=other/astyle/astylerc \
+  > toxav/toxav.h
 ```
 
 You may want to make sure with ``git diff`` that changes made in ``tox.h`` reflect changes in ``tox.in.h``.
@@ -43,7 +45,7 @@ If you prefer to have more control over what is happening, there are steps below
 4. Use ``apidsl`` ``??``
 5. Parse generated ``tox.h`` with astyle, minimal command for it would be:
 ```bash
-astyle --options=./other/astyle/astylerc ./toxcore/tox.h
+astyle --options=other/astyle/astylerc toxcore/tox.h
 ```
 
 **Always pass output from ``apidsl`` through astyle.**

--- a/other/apidsl/tox.in.h
+++ b/other/apidsl/tox.in.h
@@ -86,6 +86,19 @@ extern "C" {
  * callback will result in no callback being registered for that event. Only
  * one callback per event can be registered, so if a client needs multiple
  * event listeners, it needs to implement the dispatch functionality itself.
+ *
+ * The last argument to a callback is the user data pointer. It is passed from
+ * ${tox.iterate} to each callback in sequence.
+ *
+ * The user data pointer is never stored or dereferenced by any library code, so
+ * can be any pointer, including NULL. Callbacks must all operate on the same
+ * object type. In the apidsl code (tox.in.h), this is denoted with `any`. The
+ * `any` in ${tox.iterate} must be the same `any` as in all callbacks. In C,
+ * lacking parametric polymorphism, this is a pointer to void.
+ *
+ * Old style callbacks that are registered together with a user data pointer
+ * receive that pointer as argument when they are called. They can each have
+ * their own user data pointer of their own type.
  */
 
 /** \subsection threading Threading implications
@@ -713,7 +726,7 @@ inline namespace self {
    *
    * TODO: how long should a client wait before bootstrapping again?
    */
-  event connection_status {
+  event connection_status const {
     /**
      * @param connection_status Whether we are connected to the DHT.
      */
@@ -734,7 +747,7 @@ const uint32_t iteration_interval();
  * The main loop that needs to be run in intervals of $iteration_interval()
  * milliseconds.
  */
-void iterate();
+void iterate(any user_data);
 
 
 /*******************************************************************************
@@ -858,7 +871,6 @@ inline namespace self {
      *   If this parameter is NULL, the function has no effect.
      */
     get();
-
   }
 
 
@@ -1057,7 +1069,6 @@ namespace friend {
    * it does.
    */
   const bool exists(uint32_t friend_number);
-
 
 }
 

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
         printf("%s\n", name);
 
         m_send_message_generic(m, num, MESSAGE_NORMAL, (uint8_t *)"Test", 5, 0);
-        do_messenger(m);
+        do_messenger(m, NULL);
         c_sleep(30);
         FILE *file = fopen("Save.bak", "wb");
 

--- a/testing/irc_syncbot.c
+++ b/testing/irc_syncbot.c
@@ -349,7 +349,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        tox_iterate(tox);
+        tox_iterate(tox, NULL);
         usleep(1000 * 50);
     }
 

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -389,7 +389,7 @@ void line_eval(Tox *m, char *line)
 
             new_lines(numstring);
         } else if (inpt_command == 'd') {
-            tox_iterate(m);
+            tox_iterate(m, NULL);
         } else if (inpt_command == 'm') { //message command: /m friendnumber messsage
             char *posi[1];
             int num = strtoul(line + prompt_offset, posi, 0);
@@ -1354,7 +1354,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        tox_iterate(m);
+        tox_iterate(m, NULL);
         do_refresh();
 
         int c = timeout_getch(m);

--- a/testing/tox_shell.c
+++ b/testing/tox_shell.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
             tox_friend_send_message(tox, num, TOX_MESSAGE_TYPE_NORMAL, buf, ret, 0);
         }
 
-        tox_iterate(tox);
+        tox_iterate(tox, NULL);
         c_sleep(1);
     }
 

--- a/testing/tox_sync.c
+++ b/testing/tox_sync.c
@@ -320,7 +320,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        tox_iterate(tox);
+        tox_iterate(tox, NULL);
         c_sleep(1);
     }
 

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -816,10 +816,9 @@ void m_callback_connectionstatus(Messenger *m, void (*function)(Messenger *m, ui
     m->friend_connectionstatuschange_userdata = userdata;
 }
 
-void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, unsigned int, void *), void *userdata)
+void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, unsigned int, void *))
 {
     m->core_connection_change = function;
-    m->core_connection_change_userdata = userdata;
 }
 
 void m_callback_connectionstatus_internal_av(Messenger *m, void (*function)(Messenger *m, uint32_t, uint8_t, void *),
@@ -2232,13 +2231,13 @@ void do_friends(Messenger *m)
     }
 }
 
-static void connection_status_cb(Messenger *m)
+static void connection_status_cb(Messenger *m, void *userdata)
 {
     unsigned int conn_status = onion_connection_status(m->onion_c);
 
     if (conn_status != m->last_connection_status) {
         if (m->core_connection_change)
-            (*m->core_connection_change)(m, conn_status, m->core_connection_change_userdata);
+            (*m->core_connection_change)(m, conn_status, userdata);
 
         m->last_connection_status = conn_status;
     }
@@ -2282,7 +2281,7 @@ uint32_t messenger_run_interval(const Messenger *m)
 }
 
 /* The main loop that needs to be run at least 20 times per second. */
-void do_messenger(Messenger *m)
+void do_messenger(Messenger *m, void *userdata)
 {
     // Add the TCP relays, but only if this is the first time calling do_messenger
     if (m->has_added_relays == 0) {
@@ -2319,7 +2318,7 @@ void do_messenger(Messenger *m)
     do_onion_client(m->onion_c);
     do_friend_connections(m->fr_c);
     do_friends(m);
-    connection_status_cb(m);
+    connection_status_cb(m, userdata);
 
 #ifdef TOX_LOGGER
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -277,7 +277,6 @@ struct Messenger {
     void *lossless_packethandler_userdata;
 
     void (*core_connection_change)(struct Messenger *m, unsigned int, void *);
-    void *core_connection_change_userdata;
     unsigned int last_connection_status;
 
     Messenger_Options options;
@@ -540,7 +539,7 @@ void m_callback_connectionstatus_internal_av(Messenger *m, void (*function)(Mess
 /* Set the callback for typing changes.
  *  Function(unsigned int connection_status (0 = not connected, 1 = TCP only, 2 = UDP + TCP))
  */
-void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, unsigned int, void *), void *userdata);
+void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, unsigned int, void *));
 
 /**********GROUP CHATS************/
 
@@ -747,7 +746,7 @@ Messenger *new_messenger(Messenger_Options *options, unsigned int *error);
 void kill_messenger(Messenger *m);
 
 /* The main loop that needs to be run at least 20 times per second. */
-void do_messenger(Messenger *m);
+void do_messenger(Messenger *m, void *userdata);
 
 /* Return the time in milliseconds before do_messenger() should be called again
  * for optimal performance.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -390,10 +390,10 @@ TOX_CONNECTION tox_self_get_connection_status(const Tox *tox)
 }
 
 
-void tox_callback_self_connection_status(Tox *tox, tox_self_connection_status_cb *function, void *user_data)
+void tox_callback_self_connection_status(Tox *tox, tox_self_connection_status_cb *function)
 {
     Messenger *m = tox;
-    m_callback_core_connection(m, function, user_data);
+    m_callback_core_connection(m, function);
 }
 
 uint32_t tox_iteration_interval(const Tox *tox)
@@ -402,10 +402,10 @@ uint32_t tox_iteration_interval(const Tox *tox)
     return messenger_run_interval(m);
 }
 
-void tox_iterate(Tox *tox)
+void tox_iterate(Tox *tox, void *userdata)
 {
     Messenger *m = tox;
-    do_messenger(m);
+    do_messenger(m, userdata);
     do_groupchats(m->group_chat_object);
 }
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -84,6 +84,19 @@ extern "C" {
  * callback will result in no callback being registered for that event. Only
  * one callback per event can be registered, so if a client needs multiple
  * event listeners, it needs to implement the dispatch functionality itself.
+ *
+ * The last argument to a callback is the user data pointer. It is passed from
+ * tox_iterate to each callback in sequence.
+ *
+ * The user data pointer is never stored or dereferenced by any library code, so
+ * can be any pointer, including NULL. Callbacks must all operate on the same
+ * object type. In the apidsl code (tox.in.h), this is denoted with `any`. The
+ * `any` in tox_iterate must be the same `any` as in all callbacks. In C,
+ * lacking parametric polymorphism, this is a pointer to void.
+ *
+ * Old style callbacks that are registered together with a user data pointer
+ * receive that pointer as argument when they are called. They can each have
+ * their own user data pointer of their own type.
  */
 /** \subsection threading Threading implications
  *
@@ -776,7 +789,7 @@ typedef void tox_self_connection_status_cb(Tox *tox, TOX_CONNECTION connection_s
  *
  * TODO: how long should a client wait before bootstrapping again?
  */
-void tox_callback_self_connection_status(Tox *tox, tox_self_connection_status_cb *callback, void *user_data);
+void tox_callback_self_connection_status(Tox *tox, tox_self_connection_status_cb *callback);
 
 /**
  * Return the time in milliseconds before tox_iterate() should be called again
@@ -788,7 +801,7 @@ uint32_t tox_iteration_interval(const Tox *tox);
  * The main loop that needs to be run in intervals of tox_iteration_interval()
  * milliseconds.
  */
-void tox_iterate(Tox *tox);
+void tox_iterate(Tox *tox, void *user_data);
 
 
 /*******************************************************************************


### PR DESCRIPTION
**What are we doing?**

We are moving towards stateless callbacks. This means that when registering a
callback, you no longer pass a user data pointer. Instead, you pass a user data
pointer to tox_iterate. This pointer is threaded through the code, passed to
each callback. The callback can modify the data pointed at. An extra indirection
will be needed if the pointer itself can change.

**Why?**

Currently, callbacks are registered with a user data pointer. This means the
library has N pointers for N different callbacks. These pointers need to be
managed by the client code. Managing the lifetime of the pointee can be
difficult. In C++, it takes special effort to ensure that the lifetime of user
data extends at least beyond the lifetime of the Tox instance. For other
languages, the situation is much worse. Java and other garbage collected
languages may move objects in memory, so the pointers are not stable. Tox4j goes
through a lot of effort to make the Java/Scala user experience a pleasant one by
keeping a global array of Tox+userdata on the C++ side, and communicating via
protobufs. A Haskell FFI would have to do similarly complex tricks.

Stateless callbacks ensure that a user data pointer only needs to live during a
single function call. This means that the user code (or language runtime) can
move the data around at will, as long as it sets the new location in the
callback.

**How?**

We are doing this change one callback at a time. After each callback, we ensure
that everything still works as expected. This means the toxcore change will
require 15 Pull Requests.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/27)
<!-- Reviewable:end -->
