### PR TITLE
1. Move toxcore travis build scripts out of .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: c
 compiler:
-  - gcc
   - clang
+  - gcc
+
+env:
+  matrix:
+#    - BUILD=hstox
+    - BUILD=toxcore
 
 addons:
   apt:
@@ -10,90 +15,27 @@ addons:
     packages:
       - check
       - libvpx-dev
-      - opam
+      - opam            # For apidsl and Frama-C.
+      - texinfo         # For libconfig.
 
 cache:
   directories:
     - $HOME/cache
 
-before_script:
-  - pushd ..
-  - CACHE_DIR=$HOME/cache
+install:
+  # Globally used environment variables.
+  - export CACHE_DIR=$HOME/cache
   - export OPAMROOT=$CACHE_DIR/.opam
   - export PKG_CONFIG_PATH=$CACHE_DIR/lib/pkgconfig
-  # Set up opam.
-  - opam init -y
-  - eval `opam config env`
-  # Install required opam packages.
-  - opam install -y ocamlfind ppx_deriving menhir
-  # Build apidsl.
-  - git clone --depth=1 https://github.com/iphydf/apidsl
-  - make -C apidsl
-  # Install cpp-coveralls to upload test coverage results.
-  - pip install --user cpp-coveralls
-  # Install astyle (version in ubuntu-precise too old).
-  - ASTYLE=$CACHE_DIR/astyle/build/gcc/bin/astyle
-  - >
-      [ -f $ASTYLE ] || {
-        wget -O astyle.tar.gz http://sourceforge.net/projects/astyle/files/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz/download
-        tar -xf astyle.tar.gz -C $CACHE_DIR
-        make -C $CACHE_DIR/astyle/build/gcc
-      }
-  # Install libsodium (not in ubuntu-precise).
-  - >
-      [ -f $CACHE_DIR/lib/libsodium.a ] || {
-        git clone --depth=1 --branch=stable https://github.com/jedisct1/libsodium
-        cd libsodium
-        ./autogen.sh
-        ./configure --prefix=$CACHE_DIR
-        make install -j3
-        cd ..
-      }
-  # Install libconfig (version in ubuntu-precise too old).
-  - >
-      [ -f $CACHE_DIR/lib/libconfig.a ] || {
-        git clone --depth=1 --branch=REL1_6_STABLE https://github.com/hyperrealm/libconfig
-        cd libconfig
-        autoreconf -fi
-        ./configure --prefix=$CACHE_DIR
-        touch lib/scanner.l
-        make install -j3
-        cd ..
-      }
-  # Install libopus (not in ubuntu-precise).
-  - >
-      [ -f $CACHE_DIR/lib/libopus.a ] || {
-        git clone --depth=1 --branch=1.1.2 https://github.com/xiph/opus
-        cd opus
-        ./autogen.sh
-        ./configure --prefix=$CACHE_DIR
-        make install -j3
-        cd ..
-      }
-  - popd
+  - export ASTYLE=$CACHE_DIR/astyle/build/gcc/bin/astyle
+  # Install required packages.
+  - other/travis/${BUILD}-install
 
 script:
-  # Check if toxcore.h and toxav.h match apidsl tox.in.h and toxav.in.h.
-  - ../apidsl/_build/apigen.native ./other/apidsl/tox.in.h   | $ASTYLE --options=./other/astyle/astylerc > toxcore/tox.h
-  - ../apidsl/_build/apigen.native ./other/apidsl/toxav.in.h | $ASTYLE --options=./other/astyle/astylerc > toxav/toxav.h
-  - git diff --exit-code
-  # Build toxcore and run tests.
-  - ./autogen.sh
-  - >
-      ./configure \
-        --with-libsodium-libs=$CACHE_DIR/lib \
-        --with-libsodium-headers=$CACHE_DIR/include \
-        --enable-daemon \
-        --enable-logging \
-        --enable-ntox \
-        CFLAGS="-O0 -Wall -Wextra -fprofile-arcs -ftest-coverage -DTRAVIS_ENV"
-  - make
-  - make check
-  - if [ -f build/test-suite.log ]; then cat build/test-suite.log; fi
-  - make dist
+  - other/travis/${BUILD}-script
 
 after_script:
-  - coveralls --exclude auto_tests --exclude other --exclude testing --gcov-options '\-lp'
+  - other/travis/${BUILD}-after_script
 
 notifications:
   irc: "chat.freenode.net#toktok-status"

--- a/other/travis/toxcore-after_script
+++ b/other/travis/toxcore-after_script
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e -x
+
+coveralls               \
+  --exclude auto_tests  \
+  --exclude other       \
+  --exclude testing     \
+  --gcov-options '\-lp'

--- a/other/travis/toxcore-install
+++ b/other/travis/toxcore-install
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+set -e -x
+
+cd ..
+
+# Set up opam.
+opam init -y
+eval `opam config env`
+
+# Install required opam packages.
+opam install -y ocamlfind ppx_deriving menhir
+
+# Build apidsl.
+git clone --depth=1 https://github.com/iphydf/apidsl
+make -C apidsl
+
+# Install cpp-coveralls to upload test coverage results.
+pip install --user cpp-coveralls
+
+# Install astyle (version in ubuntu-precise too old).
+[ -f $ASTYLE ] || {
+  wget -O astyle.tar.gz https://launchpad.net/ubuntu/+archive/primary/+files/astyle_2.05.1.orig.tar.gz
+  tar -xf astyle.tar.gz -C $CACHE_DIR
+  make -C $CACHE_DIR/astyle/build/gcc
+}
+
+# Install libsodium (not in ubuntu-precise).
+[ -f $CACHE_DIR/lib/libsodium.a ] || {
+  git clone --depth=1 --branch=stable https://github.com/jedisct1/libsodium
+  cd libsodium
+  ./autogen.sh
+  ./configure --prefix=$CACHE_DIR
+  make install -j3
+  cd ..
+}
+
+# Install libconfig (version in ubuntu-precise too old).
+[ -f $CACHE_DIR/lib/libconfig.a ] || {
+  git clone --depth=1 --branch=REL1_6_STABLE https://github.com/hyperrealm/libconfig
+  cd libconfig
+  autoreconf -fi
+  ./configure --prefix=$CACHE_DIR
+  touch lib/scanner.l
+  make install -j3
+  cd ..
+}
+
+# Install libopus (not in ubuntu-precise).
+[ -f $CACHE_DIR/lib/libopus.a ] || {
+  git clone --depth=1 --branch=1.1.2 https://github.com/xiph/opus
+  cd opus
+  ./autogen.sh
+  ./configure --prefix=$CACHE_DIR
+  make install -j3
+  cd ..
+}

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e -x
+
+# Check if toxcore.h and toxav.h match apidsl tox.in.h and toxav.in.h.
+../apidsl/_build/apigen.native ./other/apidsl/tox.in.h   | $ASTYLE --options=./other/astyle/astylerc > toxcore/tox.h
+../apidsl/_build/apigen.native ./other/apidsl/toxav.in.h | $ASTYLE --options=./other/astyle/astylerc > toxav/toxav.h
+git diff --exit-code
+
+# Build toxcore and run tests.
+./autogen.sh
+./configure \
+  --with-libsodium-libs=$CACHE_DIR/lib \
+  --with-libsodium-headers=$CACHE_DIR/include \
+  --enable-daemon \
+  --enable-logging \
+  --enable-ntox \
+  CFLAGS="-O0 -Wall -Wextra -fprofile-arcs -ftest-coverage -DTRAVIS_ENV=1"
+
+make
+make check
+if [ -f build/test-suite.log ]; then
+  cat build/test-suite.log
+fi
+make dist


### PR DESCRIPTION
This is in preparation for having multiple types of build. One of the future
builds will be a hstox build, another may be frama-c or some other static
analyser. It makes sense to split these up into multiple builds, because each of
them can take a while, and running them in parallel will speed things up. Also,
the hstox test coverage should be reported separately from the toxcore auto_test
coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/29)
<!-- Reviewable:end -->
