### PR TITLE
Fix a bug I introduced that would make toxcore fail to initialise a second time

### DIFF
--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -452,7 +452,7 @@ int networking_at_startup(void)
     randombytes_stir();
 #else
 
-    if (sodium_init() != 0)
+    if (sodium_init() == -1)
         return -1;
 
 #endif /*USE_RANDOMBYTES_STIR*/


### PR DESCRIPTION
sodium_init returns 1 when the library was already initialised. Toxcore code
wasn't prepared to handle sodium errors, so it thought it was an allocation
error.

This error is still not handled correctly. If crypto fails to initialise, it
will think it's an allocation error. Fixing this requires too many code changes,
so must be done later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/32)
<!-- Reviewable:end -->
