### PR TITLE
Add missing DHT_bootstrap to CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if(LOGGING)
     -DLOGGER_OUTPUT_FILE="libtoxcore.log")
 endif()
 
+option(DEBUG "Enable assertions and other debugging facilities" OFF)
+if(DEBUG)
+  add_definitions(-DTOX_DEBUG=1)
+endif()
+
 find_package(PkgConfig REQUIRED)
 find_package(Threads   REQUIRED)
 
@@ -99,6 +104,10 @@ add_library(toxnetwork ${LIBTYPE}
   toxcore/network.c
   toxcore/util.c)
 target_link_libraries(toxnetwork toxcrypto)
+if(RT_LIBRARIES)
+  target_link_libraries(toxnetwork ${RT_LIBRARIES})
+  set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} "-lrt")
+endif()
 
 # LAYER 3: Distributed Hash Table
 # -------------------------------
@@ -151,10 +160,6 @@ target_link_libraries(toxcore toxgroup)
 target_link_libraries(toxcore ${CMAKE_THREAD_LIBS_INIT})
 if(CMAKE_THREAD_LIBS_INIT)
   set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} "-l${CMAKE_THREAD_LIBS_INIT}")
-endif()
-if(RT_LIBRARIES)
-  target_link_libraries(toxnetwork ${RT_LIBRARIES})
-  set(toxcore_PKGCONFIG_LIBS ${toxcore_PKGCONFIG_LIBS} "-lrt")
 endif()
 
 if(WIN32)
@@ -235,6 +240,11 @@ auto_test(toxav_many_test)
 #
 ################################################################################
 
+add_executable(DHT_bootstrap
+  other/DHT_bootstrap.c
+  other/bootstrap_node_packets.c)
+target_link_libraries(DHT_bootstrap toxnetcrypto)
+
 if(LIBCONFIG_FOUND)
   add_executable(tox-bootstrapd
     other/bootstrap_daemon/src/command_line_arguments.c
@@ -249,7 +259,7 @@ if(LIBCONFIG_FOUND)
     other/bootstrap_node_packets.c
     other/bootstrap_node_packets.h)
 
-  target_link_libraries(tox-bootstrapd toxcore ${LIBCONFIG_LIBRARIES})
+  target_link_libraries(tox-bootstrapd toxnetcrypto ${LIBCONFIG_LIBRARIES})
 endif()
 
 
@@ -265,10 +275,10 @@ if(NOT WIN32)
 endif()
 
 add_executable(DHT_test testing/DHT_test.c)
-target_link_libraries(DHT_test toxcore)
+target_link_libraries(DHT_test toxdht)
 
 add_executable(Messenger_test testing/Messenger_test.c)
-target_link_libraries(Messenger_test toxcore)
+target_link_libraries(Messenger_test toxmessenger)
 
 add_executable(dns3_test testing/dns3_test.c)
 target_link_libraries(dns3_test toxdns)

--- a/other/travis/autotools-script
+++ b/other/travis/autotools-script
@@ -5,7 +5,7 @@ set -e -u -x
 
 # Build toxcore and run tests.
 ./autogen.sh
-RUN ./configure \
+./configure \
   --with-libsodium-libs=$CACHE_DIR/lib \
   --with-libsodium-headers=$CACHE_DIR/include \
   --enable-daemon \
@@ -15,4 +15,4 @@ RUN ./configure \
 # We use make instead of RUN $MAKE here, because the autotools build will only
 # ever run natively on the Linux container, never on a Windows cross compilation
 # docker instance or an OSX machine.
-make distcheck -j`nproc` -k
+make distcheck -j$NPROC -k

--- a/other/travis/env-linux.sh
+++ b/other/travis/env-linux.sh
@@ -8,3 +8,4 @@ RUN() {
 export CMAKE=cmake
 export MAKE=make
 export PREFIX=$PWD/_install
+export NPROC=`nproc`

--- a/other/travis/toxcore-install
+++ b/other/travis/toxcore-install
@@ -12,7 +12,7 @@ opam install -y ocamlfind ppx_deriving menhir
 
 # Build apidsl.
 git clone --depth=1 https://github.com/iphydf/apidsl ../apidsl
-make -C ../apidsl -j`nproc`
+make -C ../apidsl -j$NPROC
 
 # Install cpp-coveralls to upload test coverage results.
 pip install --user cpp-coveralls
@@ -21,7 +21,7 @@ pip install --user cpp-coveralls
 [ -f $ASTYLE ] || {
   wget -O ../astyle.tar.gz https://launchpad.net/ubuntu/+archive/primary/+files/astyle_2.05.1.orig.tar.gz
   tar -xf ../astyle.tar.gz -C $CACHE_DIR
-  make -C $CACHE_DIR/astyle/build/gcc -j`nproc`
+  make -C $CACHE_DIR/astyle/build/gcc -j$NPROC
 }
 
 # Install libsodium (not in ubuntu-precise).
@@ -30,7 +30,7 @@ pip install --user cpp-coveralls
   cd ../libsodium # pushd
   ./autogen.sh
   ./configure --prefix=$CACHE_DIR
-  make install -j`nproc`
+  make install -j$NPROC
   cd - # popd
 }
 
@@ -41,7 +41,7 @@ pip install --user cpp-coveralls
   autoreconf -fi
   ./configure --prefix=$CACHE_DIR
   touch lib/scanner.l
-  make install -j`nproc`
+  make install -j$NPROC
   cd - # popd
 }
 
@@ -51,6 +51,6 @@ pip install --user cpp-coveralls
   cd ../opus # pushd
   ./autogen.sh
   ./configure --prefix=$CACHE_DIR
-  make install -j`nproc`
+  make install -j$NPROC
   cd - # popd
 }

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -11,10 +11,10 @@ $ASTYLE --options=other/astyle/astylerc `find . -name "*.[ch]" -and -not -name "
 git diff --exit-code
 
 # Build toxcore and run tests.
-export CFLAGS="-O0 -Wall -Wextra -fprofile-arcs -ftest-coverage -DTRAVIS_ENV=1"
-RUN $CMAKE -B$BUILD_DIR -H. -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -DLOGGING=ON
+export CFLAGS="-O3 -fprofile-arcs -ftest-coverage -DTRAVIS_ENV=1"
+RUN $CMAKE -B$BUILD_DIR -H. -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX -DLOGGING=ON -DDEBUG=ON
 
 export CTEST_OUTPUT_ON_FAILURE=1
 
-RUN $MAKE -C $BUILD_DIR -j`nproc`
-RUN $MAKE -C $BUILD_DIR -j`nproc` test
+RUN $MAKE -C $BUILD_DIR -j$NPROC -k
+RUN $MAKE -C $BUILD_DIR -j$NPROC test

--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -30,9 +30,9 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#ifdef DEBUG
+#ifdef TOX_DEBUG
 #include <assert.h>
-#endif // DEBUG
+#endif // TOX_DEBUG
 
 // You are responsible for freeing the return value!
 uint8_t *hex_string_to_bin(char *hex_string)

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -27,7 +27,7 @@
 #include "config.h"
 #endif
 
-#ifdef DEBUG
+#ifdef TOX_DEBUG
 #include <assert.h>
 #endif
 
@@ -2622,7 +2622,7 @@ static int dht_load_state_callback(void *outer, const uint8_t *data, uint32_t le
 
             break;
 
-#ifdef DEBUG
+#ifdef TOX_DEBUG
 
         default:
             fprintf(stderr, "Load state (DHT): contains unrecognized part (len %u, type %u)\n",

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -25,7 +25,7 @@
 #include "config.h"
 #endif
 
-#ifdef DEBUG
+#ifdef TOX_DEBUG
 #include <assert.h>
 #endif
 
@@ -2579,7 +2579,7 @@ void messenger_save(const Messenger *m, uint8_t *data)
     host_to_lendian32(data, MESSENGER_STATE_COOKIE_GLOBAL);
     data += size32;
 
-#ifdef DEBUG
+#ifdef TOX_DEBUG
     assert(sizeof(get_nospam(&(m->fr))) == sizeof(uint32_t));
 #endif
     len = size32 + crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
@@ -2732,7 +2732,7 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             break;
         }
 
-#ifdef DEBUG
+#ifdef TOX_DEBUG
 
         default:
             fprintf(stderr, "Load state: contains unrecognized part (len %u, type %u)\n",

--- a/toxcore/assoc.c
+++ b/toxcore/assoc.c
@@ -229,7 +229,7 @@ static hash_t hash_collide(const Assoc *assoc, hash_t hash)
      *
      * BUT: because the usage of the word "never" invokes Murphy's law, catch it */
     if (!retval) {
-#ifdef DEBUG
+#ifdef TOX_DEBUG
         fprintf(stderr, "assoc::hash_collide: hash %u, bucket size %u => %u!", hash, (uint)assoc->candidates_bucket_size,
                 retval);
         assert(retval != 0);

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -522,7 +522,7 @@ Networking_Core *new_networking_ex(IP ip, uint16_t port_from, uint16_t port_to, 
 
     /* maybe check for invalid IPs like 224+.x.y.z? if there is any IP set ever */
     if (ip.family != AF_INET && ip.family != AF_INET6) {
-#ifdef DEBUG
+#ifdef TOX_DEBUG
         fprintf(stderr, "Invalid address family: %u\n", ip.family);
 #endif
         return NULL;
@@ -545,7 +545,7 @@ Networking_Core *new_networking_ex(IP ip, uint16_t port_from, uint16_t port_to, 
 
     /* Check for socket error. */
     if (!sock_valid(temp->sock)) {
-#ifdef DEBUG
+#ifdef TOX_DEBUG
         fprintf(stderr, "Failed to get a socket?! %u, %s\n", errno, strerror(errno));
 #endif
         free(temp);

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -118,7 +118,7 @@ int load_state(load_state_callback_func load_state_callback, void *outer,
                const uint8_t *data, uint32_t length, uint16_t cookie_inner)
 {
     if (!load_state_callback || !data) {
-#ifdef DEBUG
+#ifdef TOX_DEBUG
         fprintf(stderr, "load_state() called with invalid args.\n");
 #endif
         return -1;
@@ -137,7 +137,7 @@ int load_state(load_state_callback_func load_state_callback, void *outer,
 
         if (length < length_sub) {
             /* file truncated */
-#ifdef DEBUG
+#ifdef TOX_DEBUG
             fprintf(stderr, "state file too short: %u < %u\n", length, length_sub);
 #endif
             return -1;
@@ -145,7 +145,7 @@ int load_state(load_state_callback_func load_state_callback, void *outer,
 
         if (lendian_to_host16((cookie_type >> 16)) != cookie_inner) {
             /* something is not matching up in a bad way, give up */
-#ifdef DEBUG
+#ifdef TOX_DEBUG
             fprintf(stderr, "state file garbeled: %04hx != %04hx\n", (cookie_type >> 16), cookie_inner);
 #endif
             return -1;


### PR DESCRIPTION
- This PR also adds a DEBUG cmake option that enables -DDEBUG.
- We also remove `-Wall`, because there are too many warnings, and nobody really
  looks at them at the moment. We'll see about fixing them soon. We'll also want
  to enable `-Werror` at some point.
- We also factor out `nproc` calls into the env scripts so we can use `sysctl` on OSX where `nproc` doesn't exist.
- Finally, this PR enables `-O3` to make sure toxcore still works correctly
  under heavy compiler optimisations.

<!-- Reviewable:start -->
--
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/37)
<!-- Reviewable:end -->
