### PR TITLE
Allow NULL as argument to tox_kill.

### DIFF
--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -240,6 +240,10 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
 
 void tox_kill(Tox *tox)
 {
+    if (tox == NULL) {
+        return;
+    }
+
     Messenger *m = tox;
     kill_groupchats(m->group_chat_object);
     kill_messenger(m);


### PR DESCRIPTION
This behaviour is consistent with free() and operator delete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/43)
<!-- Reviewable:end -->
