### PR TITLE
Rename the internal status change callback called by ToxAV

### DIFF
--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -2,22 +2,15 @@
 #include "config.h"
 #endif
 
-#ifndef HAVE_LIBCHECK
-#   include <assert.h>
-
-#   define ck_assert(X) assert(X);
-#   define START_TEST(NAME) void NAME ()
-#   define END_TEST
-#else
-#   include "helpers.h"
-#endif
-
 #include <sys/types.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <check.h>
 #include <time.h>
+
+#include "helpers.h"
 
 #include <vpx/vpx_image.h>
 
@@ -142,10 +135,7 @@ void *call_thread(void *pd)
         TOXAV_ERR_CALL rc;
         toxav_call(AliceAV, friend_number, 48, 3000, &rc);
 
-        if (rc != TOXAV_ERR_CALL_OK) {
-            printf("toxav_call failed: %d\n", rc);
-            ck_assert(0);
-        }
+        ck_assert_msg(rc == TOXAV_ERR_CALL_OK, "toxav_call failed: %d\n", rc);
     }
 
     while (!BobCC->incoming)
@@ -155,10 +145,7 @@ void *call_thread(void *pd)
         TOXAV_ERR_ANSWER rc;
         toxav_answer(BobAV, 0, 8, 500, &rc);
 
-        if (rc != TOXAV_ERR_ANSWER_OK) {
-            printf("toxav_answer failed: %d\n", rc);
-            ck_assert(0);
-        }
+        ck_assert_msg(rc == TOXAV_ERR_ANSWER_OK, "toxav_answer failed: %d\n", rc);
     }
 
     c_sleep(30);
@@ -340,16 +327,6 @@ START_TEST(test_AV_three_calls)
 END_TEST
 
 
-#ifndef HAVE_LIBCHECK
-int main(int argc, char *argv[])
-{
-    (void) argc;
-    (void) argv;
-
-    test_AV_three_calls();
-    return 0;
-}
-#else
 Suite *tox_suite(void)
 {
     Suite *s = suite_create("ToxAV");
@@ -379,4 +356,3 @@ int main(int argc, char *argv[])
 
     return number_failed;
 }
-#endif

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -129,7 +129,7 @@ MSISession *msi_new (Messenger *m)
     m_callback_msi_packet(m, handle_msi_packet, retu);
 
     /* This is called when remote terminates session */
-    m_callback_connectionstatus_internal_av(m, on_peer_status, retu);
+    m_callback_connstatus_av(m, on_peer_status, retu);
 
     LOGGER_DEBUG("New msi session: %p ", retu);
     return retu;

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -381,8 +381,8 @@ int m_delfriend(Messenger *m, int32_t friendnumber)
     if (friend_not_valid(m, friendnumber))
         return -1;
 
-    if (m->friend_connectionstatuschange_internal)
-        m->friend_connectionstatuschange_internal(m, friendnumber, 0, m->friend_connectionstatuschange_internal_userdata);
+    if (m->friend_connectionstatuschange_av)
+        m->friend_connectionstatuschange_av(m, friendnumber, 0, m->friend_connectionstatuschange_avdata);
 
     clear_receipts(m, friendnumber);
     remove_request_received(&(m->fr), m->friendlist[friendnumber].real_pk);
@@ -817,11 +817,11 @@ void m_callback_core_connection(Messenger *m, void (*function)(Messenger *m, uns
     m->core_connection_change = function;
 }
 
-void m_callback_connectionstatus_internal_av(Messenger *m, void (*function)(Messenger *m, uint32_t, uint8_t, void *),
-        void *userdata)
+void m_callback_connstatus_av(Messenger *m, void (*function)(Messenger *m, uint32_t, uint8_t, void *),
+                              void *userdata)
 {
-    m->friend_connectionstatuschange_internal = function;
-    m->friend_connectionstatuschange_internal_userdata = userdata;
+    m->friend_connectionstatuschange_av = function;
+    m->friend_connectionstatuschange_avdata = userdata;
 }
 
 static void check_friend_tcp_udp(Messenger *m, int32_t friendnumber)
@@ -873,9 +873,9 @@ static void check_friend_connectionstatus(Messenger *m, int32_t friendnumber, ui
 
         check_friend_tcp_udp(m, friendnumber);
 
-        if (m->friend_connectionstatuschange_internal)
-            m->friend_connectionstatuschange_internal(m, friendnumber, is_online,
-                    m->friend_connectionstatuschange_internal_userdata);
+        if (m->friend_connectionstatuschange_av)
+            m->friend_connectionstatuschange_av(m, friendnumber, is_online,
+                                                m->friend_connectionstatuschange_avdata);
     }
 }
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -249,8 +249,6 @@ struct Messenger {
     void *read_receipt_userdata;
     void (*friend_connectionstatuschange)(struct Messenger *m, uint32_t, unsigned int, void *);
     void *friend_connectionstatuschange_userdata;
-    void (*friend_connectionstatuschange_internal)(struct Messenger *m, uint32_t, uint8_t, void *);
-    void *friend_connectionstatuschange_internal_userdata;
 
     void *group_chat_object; /* Set by new_groupchats()*/
     void (*group_invite)(struct Messenger *m, uint32_t, const uint8_t *, uint16_t);
@@ -268,6 +266,9 @@ struct Messenger {
 
     void (*msi_packet)(struct Messenger *m, uint32_t, const uint8_t *, uint16_t, void *);
     void *msi_packet_userdata;
+    /* The following callback is used in ToxAV to notify ToxAV about friend status changes */
+    void (*friend_connectionstatuschange_av)(struct Messenger *m, uint32_t, uint8_t, void *);
+    void *friend_connectionstatuschange_avdata;
 
     void (*lossy_packethandler)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
     void *lossy_packethandler_userdata;
@@ -527,9 +528,10 @@ void m_callback_read_receipt(Messenger *m, void (*function)(Messenger *m, uint32
  */
 void m_callback_connectionstatus(Messenger *m, void (*function)(Messenger *m, uint32_t, unsigned int, void *),
                                  void *userdata);
+
 /* Same as previous but for internal A/V core usage only */
-void m_callback_connectionstatus_internal_av(Messenger *m, void (*function)(Messenger *m, uint32_t, uint8_t, void *),
-        void *userdata);
+void m_callback_connstatus_av(Messenger *m, void (*function)(Messenger *m, uint32_t, uint8_t, void *),
+                              void *userdata);
 
 
 /* Set the callback for typing changes.


### PR DESCRIPTION
Storing the ToxAV data pointer here should be a safe exception, as once a ToxAV instance is linked to a tox instance, there should be no reason for it to change. And as the only data stored in this void* should be C, it we don't (yet) need to worry about GC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/47)
<!-- Reviewable:end -->
