### PR TITLE
Replace uint with unsigned int in assoc.c.

### DIFF
--- a/toxcore/assoc.c
+++ b/toxcore/assoc.c
@@ -230,8 +230,8 @@ static hash_t hash_collide(const Assoc *assoc, hash_t hash)
      * BUT: because the usage of the word "never" invokes Murphy's law, catch it */
     if (!retval) {
 #ifdef TOX_DEBUG
-        fprintf(stderr, "assoc::hash_collide: hash %u, bucket size %u => %u!", hash, (uint)assoc->candidates_bucket_size,
-                retval);
+        fprintf(stderr, "assoc::hash_collide: hash %u, bucket size %u => %u!", hash,
+                (unsigned int)assoc->candidates_bucket_size, retval);
         assert(retval != 0);
 #endif
         retval = 1;


### PR DESCRIPTION
uint is not a valid type on Windows. It's also not a valid type in C, but Linux
and OSX define it somewhere. We can't rely on its existence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/59)
<!-- Reviewable:end -->
