### PR TITLE
Make friend requests stateless

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -633,7 +633,7 @@ END_TEST
 
 _Bool tcp_oobdata_callback_called;
 static int tcp_oobdata_callback(void *object, const uint8_t *public_key, unsigned int id, const uint8_t *data,
-                                uint16_t length)
+                                uint16_t length, void *userdata)
 {
     if (length != 6) {
         return -1;

--- a/auto_tests/encryptsave_test.c
+++ b/auto_tests/encryptsave_test.c
@@ -60,7 +60,7 @@ START_TEST(test_save_friend)
     Tox *tox2 = tox_new(0, 0);
     ck_assert_msg(tox1 || tox2, "Failed to create 2 tox instances");
     uint32_t to_compare = 974536;
-    tox_callback_friend_request(tox2, accept_friend_request, &to_compare);
+    tox_callback_friend_request(tox2, accept_friend_request);
     uint8_t address[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox2, address);
     uint32_t test = tox_friend_add(tox1, address, (uint8_t *)"Gentoo", 7, 0);

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -342,7 +342,7 @@ _Bool first, last;
 uint8_t first_dht_pk[crypto_box_PUBLICKEYBYTES];
 uint8_t last_dht_pk[crypto_box_PUBLICKEYBYTES];
 
-static void dht_pk_callback(void *object, int32_t number, const uint8_t *dht_public_key)
+static void dht_pk_callback(void *object, int32_t number, const uint8_t *dht_public_key, void *userdata)
 {
     if ((NUM_FIRST == number && !first) || (NUM_LAST == number && !last)) {
         Onions *on = object;

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -462,7 +462,7 @@ START_TEST(test_few_clients)
     uint32_t to_compare = 974536;
     connected_t1 = 0;
     tox_callback_self_connection_status(tox1, tox_connection_status);
-    tox_callback_friend_request(tox2, accept_friend_request, &to_compare);
+    tox_callback_friend_request(tox2, accept_friend_request);
     uint8_t address[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox2, address);
     uint32_t test = tox_friend_add(tox3, address, (uint8_t *)"Gentoo", 7, 0);
@@ -849,7 +849,7 @@ START_TEST(test_many_clients)
     for (i = 0; i < NUM_TOXES; ++i) {
         toxes[i] = tox_new(0, 0);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
-        tox_callback_friend_request(toxes[i], accept_friend_request, &to_comp);
+        tox_callback_friend_request(toxes[i], accept_friend_request);
     }
 
     {
@@ -918,7 +918,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_TOXES; ++i) {
-            tox_iterate(toxes[i], NULL);
+            tox_iterate(toxes[i], &to_comp);
         }
 
         c_sleep(50);
@@ -954,7 +954,7 @@ START_TEST(test_many_clients_tcp)
 
         toxes[i] = tox_new(&opts, 0);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
-        tox_callback_friend_request(toxes[i], accept_friend_request, &to_comp);
+        tox_callback_friend_request(toxes[i], accept_friend_request);
         uint8_t dpk[TOX_PUBLIC_KEY_SIZE];
         tox_self_get_dht_id(toxes[0], dpk);
         TOX_ERR_BOOTSTRAP error = 0;
@@ -1018,7 +1018,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            tox_iterate(toxes[i], NULL);
+            tox_iterate(toxes[i], &to_comp);
         }
 
         c_sleep(50);
@@ -1053,7 +1053,7 @@ START_TEST(test_many_clients_tcp_b)
 
         toxes[i] = tox_new(&opts, 0);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
-        tox_callback_friend_request(toxes[i], accept_friend_request, &to_comp);
+        tox_callback_friend_request(toxes[i], accept_friend_request);
         uint8_t dpk[TOX_PUBLIC_KEY_SIZE];
         tox_self_get_dht_id(toxes[(i % NUM_TCP_RELAYS)], dpk);
         ck_assert_msg(tox_add_tcp_relay(toxes[i], TOX_LOCALHOST, TCP_RELAY_PORT + (i % NUM_TCP_RELAYS), dpk, 0),
@@ -1117,7 +1117,7 @@ loop_top:
         }
 
         for (i = 0; i < NUM_TOXES_TCP; ++i) {
-            tox_iterate(toxes[i], NULL);
+            tox_iterate(toxes[i], &to_comp);
         }
 
         c_sleep(30);
@@ -1200,7 +1200,7 @@ group_test_restart:
     for (i = 0; i < NUM_GROUP_TOX; ++i) {
         toxes[i] = tox_new(0, 0);
         ck_assert_msg(toxes[i] != 0, "Failed to create tox instances %u", i);
-        tox_callback_friend_request(toxes[i], &g_accept_friend_request, &to_comp);
+        tox_callback_friend_request(toxes[i], &g_accept_friend_request);
         tox_callback_group_invite(toxes[i], &print_group_invite_callback, &to_comp);
     }
 
@@ -1231,7 +1231,7 @@ group_test_restart:
         }
 
         for (i = 0; i < NUM_GROUP_TOX; ++i) {
-            tox_iterate(toxes[i], NULL);
+            tox_iterate(toxes[i], &to_comp);
         }
 
         c_sleep(25);

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -171,7 +171,7 @@ START_TEST(test_AV_flows)
     uint32_t to_compare = 974536;
     uint8_t address[TOX_ADDRESS_SIZE];
 
-    tox_callback_friend_request(Alice, t_accept_friend_request_cb, &to_compare);
+    tox_callback_friend_request(Alice, t_accept_friend_request_cb);
     tox_self_get_address(Alice, address);
 
 

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -237,7 +237,7 @@ START_TEST(test_AV_three_calls)
     uint32_t to_compare = 974536;
     uint8_t address[TOX_ADDRESS_SIZE];
 
-    tox_callback_friend_request(Alice, t_accept_friend_request_cb, &to_compare);
+    tox_callback_friend_request(Alice, t_accept_friend_request_cb);
     tox_self_get_address(Alice, address);
 
 

--- a/other/apidsl/tox.in.h
+++ b/other/apidsl/tox.in.h
@@ -1532,7 +1532,7 @@ namespace friend {
   /**
    * This event is triggered when a friend request is received.
    */
-  event request {
+  event request const {
     /**
      * @param public_key The Public Key of the user who sent the friend request.
      * @param time_delta A delta in seconds between when the message was composed

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
         fclose(file);
     }
 
-    m_callback_friendrequest(m, print_request, NULL);
+    m_callback_friendrequest(m, print_request);
     m_callback_friendmessage(m, print_message);
 
     printf("OUR ID: ");

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -231,7 +231,7 @@ void initialize_tox(Tox **bootstrap, ToxAV **AliceAV, CallControl *AliceCC, ToxA
     uint32_t to_compare = 974536;
     uint8_t address[TOX_ADDRESS_SIZE];
 
-    tox_callback_friend_request(Alice, t_accept_friend_request_cb, &to_compare);
+    tox_callback_friend_request(Alice, t_accept_friend_request_cb);
     tox_self_get_address(Alice, address);
 
 

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -1334,7 +1334,7 @@ int main(int argc, char *argv[])
 
     save_data_file(m, filename);
 
-    tox_callback_friend_request(m, print_request, NULL);
+    tox_callback_friend_request(m, print_request);
     tox_callback_friend_message(m, print_message);
     tox_callback_friend_name(m, print_nickchange);
     tox_callback_friend_status_message(m, print_statuschange);

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -1944,7 +1944,7 @@ static int send_NATping(DHT *dht, const uint8_t *public_key, uint64_t ping_id, u
 
 /* Handle a received ping request for. */
 static int handle_NATping(void *object, IP_Port source, const uint8_t *source_pubkey, const uint8_t *packet,
-                          uint16_t length)
+                          uint16_t length, void *userdata)
 {
     if (length != sizeof(uint64_t) + 1) {
         return 1;
@@ -2243,7 +2243,7 @@ static uint32_t have_nodes_closelist(DHT *dht, Node_format *nodes, uint16_t num)
 
 /* Handle a received hardening packet */
 static int handle_hardening(void *object, IP_Port source, const uint8_t *source_pubkey, const uint8_t *packet,
-                            uint16_t length)
+                            uint16_t length, void *userdata)
 {
     DHT *dht = object;
 
@@ -2503,7 +2503,7 @@ static int cryptopacket_handle(void *object, IP_Port source, const uint8_t *pack
             }
 
             return dht->cryptopackethandlers[number].function(dht->cryptopackethandlers[number].object, source, public_key,
-                    data, len);
+                    data, len, userdata);
         }
 
         /* If request is not for us, try routing it. */

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -198,7 +198,7 @@ typedef struct {
 /*----------------------------------------------------------------------------------*/
 
 typedef int (*cryptopacket_handler_callback)(void *object, IP_Port ip_port, const uint8_t *source_pubkey,
-        const uint8_t *data, uint16_t len);
+        const uint8_t *data, uint16_t len, void *userdata);
 
 typedef struct {
     cryptopacket_handler_callback function;

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -168,7 +168,7 @@ static int send_offline_packet(Messenger *m, int friendcon_id)
                              sizeof(packet), 0) != -1;
 }
 
-static int handle_status(void *object, int i, uint8_t status);
+static int handle_status(void *object, int i, uint8_t status, void *userdata);
 static int handle_packet(void *object, int i, const uint8_t *temp, uint16_t len, void *userdata);
 static int handle_custom_lossy_packet(void *object, int friend_num, const uint8_t *packet, uint16_t length);
 
@@ -450,8 +450,8 @@ int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber)
     if (m->friendlist[friendnumber].status == FRIEND_ONLINE) {
         _Bool direct_connected = 0;
         unsigned int num_online_relays = 0;
-        crypto_connection_status(m->net_crypto, friend_connection_crypt_connection_id(m->fr_c,
-                                 m->friendlist[friendnumber].friendcon_id), &direct_connected, &num_online_relays);
+        int crypt_conn_id = friend_connection_crypt_connection_id(m->fr_c, m->friendlist[friendnumber].friendcon_id);
+        crypto_connection_status(m->net_crypto, crypt_conn_id, &direct_connected, &num_online_relays);
 
         if (direct_connected) {
             return CONNECTION_UDP;
@@ -836,10 +836,9 @@ void m_callback_log(Messenger *m, logger_cb *function, void *userdata)
 
 /* Set the function that will be executed when a friend request is received. */
 void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, const uint8_t *, size_t,
-                              void *), void *userdata)
+                              void *))
 {
-    void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, size_t, void *) = (void *)function;
-    callback_friendrequest(&(m->fr), handle_friendrequest, m, userdata);
+    callback_friendrequest(&(m->fr), (void (*)(void *, const uint8_t *, const uint8_t *, size_t, void *))function, m);
 }
 
 /* Set the function that will be executed when a message from a friend is received. */
@@ -2040,7 +2039,7 @@ static void check_friend_request_timed_out(Messenger *m, uint32_t i, uint64_t t)
     }
 }
 
-static int handle_status(void *object, int i, uint8_t status)
+static int handle_status(void *object, int i, uint8_t status, void *userdata)
 {
     Messenger *m = object;
 
@@ -2500,7 +2499,7 @@ void do_messenger(Messenger *m, void *userdata)
 
     do_net_crypto(m->net_crypto, userdata);
     do_onion_client(m->onion_c);
-    do_friend_connections(m->fr_c);
+    do_friend_connections(m->fr_c, userdata);
     do_friends(m, userdata);
     connection_status_cb(m, userdata);
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -472,7 +472,7 @@ void m_callback_log(Messenger *m, logger_cb *function, void *userdata);
  *  Function format is function(uint8_t * public_key, uint8_t * data, size_t length)
  */
 void m_callback_friendrequest(Messenger *m, void (*function)(Messenger *m, const uint8_t *, const uint8_t *, size_t,
-                              void *), void *userdata);
+                              void *));
 
 /* Set the function that will be executed when a message from a friend is received.
  *  Function format is: function(uint32_t friendnumber, unsigned int type, uint8_t * message, uint32_t length)

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -375,7 +375,8 @@ void set_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_data_c
 /* Set the callback for TCP onion packets.
  */
 void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_oob_callback)(void *object,
-        const uint8_t *public_key, unsigned int tcp_connections_number, const uint8_t *data, uint16_t length), void *object)
+        const uint8_t *public_key, unsigned int tcp_connections_number, const uint8_t *data, uint16_t length, void *userdata),
+        void *object)
 {
     tcp_c->tcp_oob_callback = tcp_oob_callback;
     tcp_c->tcp_oob_callback_object = object;
@@ -985,7 +986,7 @@ static int tcp_oob_callback(void *object, const uint8_t *public_key, const uint8
     }
 
     if (tcp_c->tcp_oob_callback) {
-        tcp_c->tcp_oob_callback(tcp_c->tcp_oob_callback_object, public_key, tcp_connections_number, data, length);
+        tcp_c->tcp_oob_callback(tcp_c->tcp_oob_callback_object, public_key, tcp_connections_number, data, length, userdata);
     }
 
     return 0;

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -94,7 +94,7 @@ typedef struct {
     void *tcp_data_callback_object;
 
     int (*tcp_oob_callback)(void *object, const uint8_t *public_key, unsigned int tcp_connections_number,
-                            const uint8_t *data, uint16_t length);
+                            const uint8_t *data, uint16_t length, void *userdata);
     void *tcp_oob_callback_object;
 
     int (*tcp_onion_callback)(void *object, const uint8_t *data, uint16_t length, void *userdata);
@@ -161,7 +161,8 @@ void set_onion_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_
 /* Set the callback for TCP oob data packets.
  */
 void set_oob_packet_tcp_connection_callback(TCP_Connections *tcp_c, int (*tcp_oob_callback)(void *object,
-        const uint8_t *public_key, unsigned int tcp_connections_number, const uint8_t *data, uint16_t length), void *object);
+        const uint8_t *public_key, unsigned int tcp_connections_number, const uint8_t *data, uint16_t length, void *userdata),
+        void *object);
 
 /* Create a new TCP connection to public_key.
  *

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -79,7 +79,7 @@ typedef struct {
     uint64_t share_relays_lastsent;
 
     struct {
-        int (*status_callback)(void *object, int id, uint8_t status);
+        int (*status_callback)(void *object, int id, uint8_t status, void *userdata);
         void *status_callback_object;
         int status_callback_id;
 
@@ -109,7 +109,8 @@ typedef struct {
     Friend_Conn *conns;
     uint32_t num_cons;
 
-    int (*fr_request_callback)(void *object, const uint8_t *source_pubkey, const uint8_t *data, uint16_t len);
+    int (*fr_request_callback)(void *object, const uint8_t *source_pubkey, const uint8_t *data, uint16_t len,
+                               void *userdata);
     void *fr_request_object;
 
     uint64_t last_LANdiscovery;
@@ -142,7 +143,7 @@ int get_friendcon_public_keys(uint8_t *real_pk, uint8_t *dht_temp_pk, Friend_Con
 
 /* Set temp dht key for connection.
  */
-void set_dht_temp_pk(Friend_Connections *fr_c, int friendcon_id, const uint8_t *dht_temp_pk);
+void set_dht_temp_pk(Friend_Connections *fr_c, int friendcon_id, const uint8_t *dht_temp_pk, void *userdata);
 
 /* Add a TCP relay associated to the friend.
  *
@@ -158,11 +159,10 @@ int friend_add_tcp_relay(Friend_Connections *fr_c, int friendcon_id, IP_Port ip_
  * return -1 on failure
  */
 int friend_connection_callbacks(Friend_Connections *fr_c, int friendcon_id, unsigned int index,
-                                int (*status_callback)(void *object, int id, uint8_t status), int (*data_callback)(void *object, int id,
-                                        const uint8_t *data,
-                                        uint16_t length, void *userdata), int (*lossy_data_callback)(void *object, int id, const uint8_t *data,
-                                                uint16_t length), void *object,
-                                int number);
+                                int (*status_callback)(void *object, int id, uint8_t status, void *userdata),
+                                int (*data_callback)(void *object, int id, const uint8_t *data, uint16_t len, void *userdata),
+                                int (*lossy_data_callback)(void *object, int id, const uint8_t *data, uint16_t length),
+                                void *object, int number);
 
 /* return the crypt_connection_id for the connection.
  *
@@ -200,13 +200,13 @@ int send_friend_request_packet(Friend_Connections *fr_c, int friendcon_id, uint3
  * This function will be called every time a friend request is received.
  */
 void set_friend_request_callback(Friend_Connections *fr_c, int (*fr_request_callback)(void *, const uint8_t *,
-                                 const uint8_t *, uint16_t), void *object);
+                                 const uint8_t *, uint16_t, void *), void *object);
 
 /* Create new friend_connections instance. */
 Friend_Connections *new_friend_connections(Onion_Client *onion_c);
 
 /* main friend_connections loop. */
-void do_friend_connections(Friend_Connections *fr_c);
+void do_friend_connections(Friend_Connections *fr_c, void *userdata);
 
 /* Free everything related with friend_connections. */
 void kill_friend_connections(Friend_Connections *fr_c);

--- a/toxcore/friend_requests.c
+++ b/toxcore/friend_requests.c
@@ -43,12 +43,11 @@ uint32_t get_nospam(const Friend_Requests *fr)
 
 /* Set the function that will be executed when a friend request is received. */
 void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const uint8_t *, const uint8_t *, size_t,
-                            void *), void *object, void *userdata)
+                            void *), void *object)
 {
     fr->handle_friendrequest = function;
     fr->handle_friendrequest_isset = 1;
     fr->handle_friendrequest_object = object;
-    fr->handle_friendrequest_userdata = userdata;
 }
 /* Set the function used to check if a friend request should be displayed to the user or not. */
 void set_filter_function(Friend_Requests *fr, int (*function)(const uint8_t *, void *), void *userdata)
@@ -106,7 +105,8 @@ int remove_request_received(Friend_Requests *fr, const uint8_t *real_pk)
 }
 
 
-static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, const uint8_t *packet, uint16_t length)
+static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, const uint8_t *packet, uint16_t length,
+                                  void *userdata)
 {
     Friend_Requests *fr = object;
 
@@ -142,8 +142,7 @@ static int friendreq_handlepacket(void *object, const uint8_t *source_pubkey, co
     memcpy(message, packet + sizeof(fr->nospam), message_len);
     message[sizeof(message) - 1] = 0; /* Be sure the message is null terminated. */
 
-    (*fr->handle_friendrequest)(fr->handle_friendrequest_object, source_pubkey, message, message_len,
-                                fr->handle_friendrequest_userdata);
+    (*fr->handle_friendrequest)(fr->handle_friendrequest_object, source_pubkey, message, message_len, userdata);
     return 0;
 }
 

--- a/toxcore/friend_requests.h
+++ b/toxcore/friend_requests.h
@@ -33,7 +33,6 @@ typedef struct {
     void (*handle_friendrequest)(void *, const uint8_t *, const uint8_t *, size_t, void *);
     uint8_t handle_friendrequest_isset;
     void *handle_friendrequest_object;
-    void *handle_friendrequest_userdata;
 
     int (*filter_function)(const uint8_t *, void *);
     void *filter_function_userdata;
@@ -62,7 +61,7 @@ int remove_request_received(Friend_Requests *fr, const uint8_t *real_pk);
  *  Function format is function(uint8_t * public_key, uint8_t * data, size_t length, void * userdata)
  */
 void callback_friendrequest(Friend_Requests *fr, void (*function)(void *, const uint8_t *, const uint8_t *, size_t,
-                            void *), void *object, void *userdata);
+                            void *), void *object);
 
 /* Set the function used to check if a friend request should be displayed to the user or not.
  * Function format is int function(uint8_t * public_key, void * userdata)

--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -327,7 +327,7 @@ static unsigned int pk_in_closest_peers(Group_c *g, uint8_t *real_pk)
 
 static int send_packet_online(Friend_Connections *fr_c, int friendcon_id, uint16_t group_num, uint8_t *identifier);
 
-static int connect_to_closest(Group_Chats *g_c, int groupnumber)
+static int connect_to_closest(Group_Chats *g_c, int groupnumber, void *userdata)
 {
     Group_c *g = get_group_c(g_c, groupnumber);
 
@@ -383,7 +383,7 @@ static int connect_to_closest(Group_Chats *g_c, int groupnumber)
                 continue;
             }
 
-            set_dht_temp_pk(g_c->fr_c, friendcon_id, g->closest_peers[i].temp_pk);
+            set_dht_temp_pk(g_c->fr_c, friendcon_id, g->closest_peers[i].temp_pk, userdata);
         }
 
         add_conn_to_groupchat(g_c, friendcon_id, groupnumber, 1, lock);
@@ -647,7 +647,7 @@ static void set_conns_status_groups(Group_Chats *g_c, int friendcon_id, uint8_t 
     }
 }
 
-static int handle_status(void *object, int friendcon_id, uint8_t status)
+static int handle_status(void *object, int friendcon_id, uint8_t status, void *userdata)
 {
     Group_Chats *g_c = object;
 
@@ -661,7 +661,7 @@ static int handle_status(void *object, int friendcon_id, uint8_t status)
     return 0;
 }
 
-static int handle_packet(void *object, int friendcon_id, uint8_t *data, uint16_t length, void *userdata);
+static int handle_packet(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata);
 static int handle_lossy(void *object, int friendcon_id, const uint8_t *data, uint16_t length);
 
 /* Add friend to group chat.
@@ -1465,7 +1465,7 @@ static int send_packet_online(Friend_Connections *fr_c, int friendcon_id, uint16
 
 static unsigned int send_peer_kill(Group_Chats *g_c, int friendcon_id, uint16_t group_num);
 
-static int handle_packet_online(Group_Chats *g_c, int friendcon_id, uint8_t *data, uint16_t length)
+static int handle_packet_online(Group_Chats *g_c, int friendcon_id, const uint8_t *data, uint16_t length)
 {
     if (length != ONLINE_PACKET_DATA_SIZE) {
         return -1;
@@ -2063,7 +2063,7 @@ static void handle_message_packet_group(Group_Chats *g_c, int groupnumber, const
     send_message_all_close(g_c, groupnumber, data, length, -1/*TODO close_index*/);
 }
 
-static int handle_packet(void *object, int friendcon_id, uint8_t *data, uint16_t length, void *userdata)
+static int handle_packet(void *object, int friendcon_id, const uint8_t *data, uint16_t length, void *userdata)
 {
     Group_Chats *g_c = object;
 
@@ -2397,7 +2397,7 @@ Group_Chats *new_groupchats(Messenger *m)
 }
 
 /* main groupchats loop. */
-void do_groupchats(Group_Chats *g_c)
+void do_groupchats(Group_Chats *g_c, void *userdata)
 {
     unsigned int i;
 
@@ -2409,7 +2409,7 @@ void do_groupchats(Group_Chats *g_c)
         }
 
         if (g->status == GROUPCHAT_STATUS_CONNECTED) {
-            connect_to_closest(g_c, i);
+            connect_to_closest(g_c, i, userdata);
             ping_groupchat(g_c, i);
             groupchat_clear_timedout(g_c, i);
         }

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -372,7 +372,7 @@ int callback_groupchat_delete(Group_Chats *g_c, int groupnumber, void (*function
 Group_Chats *new_groupchats(Messenger *m);
 
 /* main groupchats loop. */
-void do_groupchats(Group_Chats *g_c);
+void do_groupchats(Group_Chats *g_c, void *userdata);
 
 /* Free everything related with group chats. */
 void kill_groupchats(Group_Chats *g_c);

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -1297,7 +1297,7 @@ static int send_kill_packet(Net_Crypto *c, int crypt_connection_id)
                                    &kill_packet, sizeof(kill_packet));
 }
 
-static void connection_kill(Net_Crypto *c, int crypt_connection_id)
+static void connection_kill(Net_Crypto *c, int crypt_connection_id, void *userdata)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 
@@ -1306,7 +1306,8 @@ static void connection_kill(Net_Crypto *c, int crypt_connection_id)
     }
 
     if (conn->connection_status_callback) {
-        conn->connection_status_callback(conn->connection_status_callback_object, conn->connection_status_callback_id, 0);
+        conn->connection_status_callback(conn->connection_status_callback_object, conn->connection_status_callback_id, 0,
+                                         userdata);
     }
 
     crypto_kill(c, crypt_connection_id);
@@ -1370,7 +1371,7 @@ static int handle_data_packet_helper(Net_Crypto *c, int crypt_connection_id, con
     }
 
     if (real_data[0] == PACKET_ID_KILL) {
-        connection_kill(c, crypt_connection_id);
+        connection_kill(c, crypt_connection_id, userdata);
         return 0;
     }
 
@@ -1379,7 +1380,8 @@ static int handle_data_packet_helper(Net_Crypto *c, int crypt_connection_id, con
         conn->status = CRYPTO_CONN_ESTABLISHED;
 
         if (conn->connection_status_callback) {
-            conn->connection_status_callback(conn->connection_status_callback_object, conn->connection_status_callback_id, 1);
+            conn->connection_status_callback(conn->connection_status_callback_object, conn->connection_status_callback_id, 1,
+                                             userdata);
         }
     }
 
@@ -1525,7 +1527,7 @@ static int handle_packet_connection(Net_Crypto *c, int crypt_connection_id, cons
                     conn->status = CRYPTO_CONN_NOT_CONFIRMED;
                 } else {
                     if (conn->dht_pk_callback) {
-                        conn->dht_pk_callback(conn->dht_pk_callback_object, conn->dht_pk_callback_number, dht_public_key);
+                        conn->dht_pk_callback(conn->dht_pk_callback_object, conn->dht_pk_callback_number, dht_public_key, userdata);
                     }
                 }
             } else {
@@ -1729,7 +1731,8 @@ void new_connection_handler(Net_Crypto *c, int (*new_connection_callback)(void *
  * return -1 on failure.
  * return 0 on success.
  */
-static int handle_new_connection_handshake(Net_Crypto *c, IP_Port source, const uint8_t *data, uint16_t length)
+static int handle_new_connection_handshake(Net_Crypto *c, IP_Port source, const uint8_t *data, uint16_t length,
+        void *userdata)
 {
     New_Connection n_c;
     n_c.cookie = malloc(COOKIE_LENGTH);
@@ -1753,7 +1756,7 @@ static int handle_new_connection_handshake(Net_Crypto *c, IP_Port source, const 
         Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 
         if (public_key_cmp(n_c.dht_public_key, conn->dht_public_key) != 0) {
-            connection_kill(c, crypt_connection_id);
+            connection_kill(c, crypt_connection_id, userdata);
         } else {
             int ret = -1;
 
@@ -1966,7 +1969,7 @@ static int tcp_data_callback(void *object, int id, const uint8_t *data, uint16_t
 }
 
 static int tcp_oob_callback(void *object, const uint8_t *public_key, unsigned int tcp_connections_number,
-                            const uint8_t *data, uint16_t length)
+                            const uint8_t *data, uint16_t length, void *userdata)
 {
     if (length == 0 || length > MAX_CRYPTO_PACKET_SIZE) {
         return -1;
@@ -1984,7 +1987,7 @@ static int tcp_oob_callback(void *object, const uint8_t *public_key, unsigned in
         source.ip.family = TCP_FAMILY;
         source.ip.ip6.uint32[0] = tcp_connections_number;
 
-        if (handle_new_connection_handshake(c, source, data, length) != 0) {
+        if (handle_new_connection_handshake(c, source, data, length, userdata) != 0) {
             return -1;
         }
 
@@ -2119,7 +2122,7 @@ static void do_tcp(Net_Crypto *c, void *userdata)
  * return 0 on success.
  */
 int connection_status_handler(const Net_Crypto *c, int crypt_connection_id,
-                              int (*connection_status_callback)(void *object, int id, uint8_t status), void *object, int id)
+                              int (*connection_status_callback)(void *object, int id, uint8_t status, void *userdata), void *object, int id)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 
@@ -2191,7 +2194,7 @@ int connection_lossy_data_handler(Net_Crypto *c, int crypt_connection_id,
  * return 0 on success.
  */
 int nc_dht_pk_callback(Net_Crypto *c, int crypt_connection_id, void (*function)(void *data, int32_t number,
-                       const uint8_t *dht_public_key), void *object, uint32_t number)
+                       const uint8_t *dht_public_key, void *userdata), void *object, uint32_t number)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 
@@ -2239,7 +2242,7 @@ static int udp_handle_packet(void *object, IP_Port source, const uint8_t *packet
             return 1;
         }
 
-        if (handle_new_connection_handshake(c, source, packet, length) != 0) {
+        if (handle_new_connection_handshake(c, source, packet, length, userdata) != 0) {
             return 1;
         }
 
@@ -2822,7 +2825,7 @@ Net_Crypto *new_net_crypto(Logger *log, DHT *dht, TCP_Proxy_Info *proxy_info)
     return temp;
 }
 
-static void kill_timedout(Net_Crypto *c)
+static void kill_timedout(Net_Crypto *c, void *userdata)
 {
     uint32_t i;
     //uint64_t temp_time = current_time_monotonic();
@@ -2844,7 +2847,7 @@ static void kill_timedout(Net_Crypto *c)
                 continue;
             }
 
-            connection_kill(c, i);
+            connection_kill(c, i, userdata);
         }
 
 #if 0
@@ -2868,7 +2871,7 @@ uint32_t crypto_run_interval(const Net_Crypto *c)
 void do_net_crypto(Net_Crypto *c, void *userdata)
 {
     unix_time_update();
-    kill_timedout(c);
+    kill_timedout(c, userdata);
     do_tcp(c, userdata);
     send_crypto_packets(c);
 }

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -131,7 +131,7 @@ typedef struct {
     Packets_Array send_array;
     Packets_Array recv_array;
 
-    int (*connection_status_callback)(void *object, int id, uint8_t status);
+    int (*connection_status_callback)(void *object, int id, uint8_t status, void *userdata);
     void *connection_status_callback_object;
     int connection_status_callback_id;
 
@@ -174,7 +174,7 @@ typedef struct {
 
     pthread_mutex_t mutex;
 
-    void (*dht_pk_callback)(void *data, int32_t number, const uint8_t *dht_public_key);
+    void (*dht_pk_callback)(void *data, int32_t number, const uint8_t *dht_public_key, void *userdata);
     void *dht_pk_callback_object;
     uint32_t dht_pk_callback_number;
 } Crypto_Connection;
@@ -264,7 +264,7 @@ int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, 
  * return 0 on success.
  */
 int connection_status_handler(const Net_Crypto *c, int crypt_connection_id,
-                              int (*connection_status_callback)(void *object, int id, uint8_t status), void *object, int id);
+                              int (*connection_status_callback)(void *object, int id, uint8_t status, void *userdata), void *object, int id);
 
 /* Set function to be called when connection with crypt_connection_id receives a lossless data packet of length.
  *
@@ -301,7 +301,7 @@ int connection_lossy_data_handler(Net_Crypto *c, int crypt_connection_id,
  * return 0 on success.
  */
 int nc_dht_pk_callback(Net_Crypto *c, int crypt_connection_id, void (*function)(void *data, int32_t number,
-                       const uint8_t *dht_public_key), void *object, uint32_t number);
+                       const uint8_t *dht_public_key, void *userdata), void *object, uint32_t number);
 
 /* returns the number of packet slots left in the sendbuffer.
  * return 0 if failure.

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -114,7 +114,7 @@ typedef struct {
     void *tcp_relay_node_callback_object;
     uint32_t tcp_relay_node_callback_number;
 
-    void (*dht_pk_callback)(void *data, int32_t number, const uint8_t *dht_public_key);
+    void (*dht_pk_callback)(void *data, int32_t number, const uint8_t *dht_public_key, void *userdata);
     void *dht_pk_callback_object;
     uint32_t dht_pk_callback_number;
 
@@ -122,7 +122,7 @@ typedef struct {
 } Onion_Friend;
 
 typedef int (*oniondata_handler_callback)(void *object, const uint8_t *source_pubkey, const uint8_t *data,
-        uint16_t len);
+        uint16_t len, void *userdata);
 
 typedef struct {
     DHT     *dht;
@@ -239,7 +239,7 @@ int recv_tcp_relay_handler(Onion_Client *onion_c, int friend_num, int (*tcp_rela
  * return 0 on success.
  */
 int onion_dht_pk_callback(Onion_Client *onion_c, int friend_num, void (*function)(void *data, int32_t number,
-                          const uint8_t *dht_public_key), void *object, uint32_t number);
+                          const uint8_t *dht_public_key, void *userdata), void *object, uint32_t number);
 
 /* Set a friends DHT public key.
  * timestamp is the time (current_time_monotonic()) at which the key was last confirmed belonging to

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -476,7 +476,7 @@ void tox_iterate(Tox *tox, void *user_data)
 {
     Messenger *m = tox;
     do_messenger(m, user_data);
-    do_groupchats(m->group_chat_object);
+    do_groupchats(m->group_chat_object, user_data);
 }
 
 void tox_self_get_address(const Tox *tox, uint8_t *address)
@@ -963,10 +963,10 @@ void tox_callback_friend_read_receipt(Tox *tox, tox_friend_read_receipt_cb *call
     m_callback_read_receipt(m, callback);
 }
 
-void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback, void *user_data)
+void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback)
 {
     Messenger *m = tox;
-    m_callback_friendrequest(m, callback, user_data);
+    m_callback_friendrequest(m, callback);
 }
 
 void tox_callback_friend_message(Tox *tox, tox_friend_message_cb *callback)

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -1709,7 +1709,7 @@ typedef void tox_friend_request_cb(Tox *tox, const uint8_t *public_key, const ui
  *
  * This event is triggered when a friend request is received.
  */
-void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback, void *user_data);
+void tox_callback_friend_request(Tox *tox, tox_friend_request_cb *callback);
 
 /**
  * @param friend_number The friend number of the friend who sent the message.


### PR DESCRIPTION
Messenger is slightly twisty when it comes to sending connection status callbacks
It will very likely need at the very least a partial refactor to clean it up a
bit. Toxcore shouldn't need void *userdata as deep as is currently does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/60)
<!-- Reviewable:end -->
