### PR TITLE
Reduce the timeout on travis to something much more reasonable

### DIFF
--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -1312,7 +1312,7 @@ group_test_restart:
 END_TEST
 
 #ifdef TRAVIS_ENV
-uint8_t timeout_mux = 100;
+uint8_t timeout_mux = 20;
 #else
 uint8_t timeout_mux = 10;
 #endif


### PR DESCRIPTION
10x timeouts forces travis to kill our build without offering anything helpful

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/62)
<!-- Reviewable:end -->
