### PR TITLE
Initialise the id in assoc_test.

### DIFF
--- a/auto_tests/assoc_test.c
+++ b/auto_tests/assoc_test.c
@@ -18,7 +18,7 @@
 START_TEST(test_basics)
 {
     /* TODO: real test */
-    uint8_t id[crypto_box_PUBLICKEYBYTES];
+    uint8_t id[crypto_box_PUBLICKEYBYTES] = {1};
     Assoc *assoc = new_Assoc_default(id);
     ck_assert_msg(assoc != NULL, "failed to create default assoc");
 


### PR DESCRIPTION
Once every new moon, the assoc_test would fail because the key is 0. It
can be anything but 0 to succeed, so I made it 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/63)
<!-- Reviewable:end -->
