### PR TITLE
Comment out useless TODO'd if block.

### DIFF
--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -2669,12 +2669,15 @@ static void kill_timedout(Net_Crypto *c)
                 continue;
 
             connection_kill(c, i);
-
         }
+
+#if 0
 
         if (conn->status == CRYPTO_CONN_ESTABLISHED) {
             //TODO: add a timeout here?
         }
+
+#endif
     }
 }
 


### PR DESCRIPTION
The condition is a potential use after free, because `connection_kill` before it
will delete the `conn` that is dereferenced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/64)
<!-- Reviewable:end -->
