### PR TITLE
Add missing #includes to headers and rename tox_old to tox_group.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ target_link_libraries(toxgroup toxmessenger)
 # LAYER 8: Public API
 # -------------------
 add_library(toxcore ${LIBTYPE}
-  toxcore/tox.c)
+  toxcore/tox.c
+  toxcore/tox_group.c)
 target_link_libraries(toxcore toxgroup)
 
 
@@ -365,7 +366,7 @@ install(TARGETS
 install(FILES
   toxav/toxav.h
   toxcore/tox.h
-  toxcore/tox_old.h
+  toxcore/tox_group.h
   toxdns/toxdns.h
   toxencryptsave/toxencryptsave.h
   DESTINATION "include/tox")

--- a/other/apidsl/tox.in.h
+++ b/other/apidsl/tox.in.h
@@ -2198,7 +2198,7 @@ inline namespace self {
 } // class tox
 
 %{
-#include "tox_old.h"
+#include "tox_group.h"
 
 #ifdef __cplusplus
 }

--- a/toxcore/Makefile.inc
+++ b/toxcore/Makefile.inc
@@ -2,7 +2,7 @@ lib_LTLIBRARIES += libtoxcore.la
 
 libtoxcore_la_include_HEADERS = \
                         ../toxcore/tox.h \
-                        ../toxcore/tox_old.h
+                        ../toxcore/tox_group.h
 
 libtoxcore_la_includedir = $(includedir)/tox
 
@@ -28,6 +28,7 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
                         ../toxcore/ping.c \
                         ../toxcore/tox.h \
                         ../toxcore/tox.c \
+                        ../toxcore/tox_group.c \
                         ../toxcore/util.h \
                         ../toxcore/util.c \
                         ../toxcore/group.h \
@@ -50,8 +51,7 @@ libtoxcore_la_SOURCES = ../toxcore/DHT.h \
                         ../toxcore/TCP_connection.c \
                         ../toxcore/list.c \
                         ../toxcore/list.h \
-                        ../toxcore/misc_tools.h \
-                        ../toxcore/tox_old_code.h
+                        ../toxcore/misc_tools.h
 
 libtoxcore_la_CFLAGS =  -I$(top_srcdir) \
                         -I$(top_srcdir)/toxcore \

--- a/toxcore/assoc.h
+++ b/toxcore/assoc.h
@@ -1,6 +1,12 @@
-
 #ifndef __ASSOC_H__
 #define __ASSOC_H__
+
+#include "DHT.h"
+#include "logger.h"
+#include "network.h"
+
+#include <stddef.h>
+#include <stdint.h>
 
 /* used by rendezvous */
 #define ASSOC_AVAILABLE

--- a/toxcore/ping.h
+++ b/toxcore/ping.h
@@ -24,6 +24,11 @@
 #ifndef __PING_H__
 #define __PING_H__
 
+#include "DHT.h"
+#include "network.h"
+
+#include <stdint.h>
+
 typedef struct PING PING;
 
 /* Add nodes to the to_ping list.

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -1341,5 +1341,3 @@ uint16_t tox_self_get_tcp_port(const Tox *tox, TOX_ERR_GET_PORT *error)
         return 0;
     }
 }
-
-#include "tox_old_code.h"

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -2462,7 +2462,7 @@ uint16_t tox_self_get_udp_port(const Tox *tox, TOX_ERR_GET_PORT *error);
  */
 uint16_t tox_self_get_tcp_port(const Tox *tox, TOX_ERR_GET_PORT *error);
 
-#include "tox_old.h"
+#include "tox_group.h"
 
 #ifdef __cplusplus
 }

--- a/toxcore/tox_group.c
+++ b/toxcore/tox_group.c
@@ -1,3 +1,38 @@
+/* tox.c
+ *
+ * The Tox public API.
+ *
+ *  Copyright (C) 2013 Tox project All Rights Reserved.
+ *
+ *  This file is part of Tox.
+ *
+ *  Tox is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Tox is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "Messenger.h"
+#include "group.h"
+
+#define TOX_DEFINED
+typedef struct Messenger Tox;
+
+#include "tox.h"
+
 /**********GROUP CHAT FUNCTIONS: WARNING Group chats will be rewritten so this might change ************/
 
 /* Set the callback for group invites.

--- a/toxcore/tox_group.h
+++ b/toxcore/tox_group.h
@@ -1,3 +1,8 @@
+#ifndef TOX_GROUP_H
+#define TOX_GROUP_H
+
+#include "tox.h"
+
 /**********GROUP CHAT FUNCTIONS ************/
 
 /* Group chat types for tox_callback_group_invite function.
@@ -171,3 +176,4 @@ uint32_t tox_get_chatlist(const Tox *tox, int32_t *out_list, uint32_t list_size)
  */
 int tox_group_get_type(const Tox *tox, int groupnumber);
 
+#endif /* TOX_GROUP_H */


### PR DESCRIPTION
Also, no longer #include the group code into tox.c. Instead, compile it
separately in tox_group.c. This is a bit less surprising to someone looking
around the code. Having some implementations in a .h file is certainly a bit
surprising to a disciplined C programmer, especially when there is no technical
reason to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/74)
<!-- Reviewable:end -->
