### PR TITLE
Remove useless casts.

### DIFF
--- a/toxav/video.c
+++ b/toxav/video.c
@@ -128,7 +128,7 @@ void vc_kill(VCSession *vc)
 
     void *p;
 
-    while (rb_read(vc->vbuf_raw, (void **)&p)) {
+    while (rb_read(vc->vbuf_raw, &p)) {
         free(p);
     }
 

--- a/toxcore/assoc.c
+++ b/toxcore/assoc.c
@@ -891,7 +891,7 @@ Assoc *new_Assoc(Logger *log, size_t bits, size_t entries, const uint8_t *public
         if (entries_test != entries) {
 
             LOGGER_DEBUG(assoc->log, "trimmed %i to %i.\n", (int)entries, (int)entries_test);
-            entries = (size_t)entries_test;
+            entries = entries_test;
         }
     }
 

--- a/toxcore/onion_announce.c
+++ b/toxcore/onion_announce.c
@@ -95,7 +95,7 @@ int create_data_request(uint8_t *packet, uint16_t max_packet_length, const uint8
         return -1;
     }
 
-    if ((unsigned int)DATA_REQUEST_MIN_SIZE + length > ONION_MAX_DATA_SIZE) {
+    if (DATA_REQUEST_MIN_SIZE + length > ONION_MAX_DATA_SIZE) {
         return -1;
     }
 


### PR DESCRIPTION
These casts are either completely useless (casting T to T) or implicit (x = y).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/84)
<!-- Reviewable:end -->
