### PR TITLE
Re-enable group chat tests.

### DIFF
--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -1373,7 +1373,7 @@ Suite *tox_suite(void)
      * Anyone reading this is welcome to try to fix it, but because there is a
      * new version of group chats for Tox already completed, and nearly ready to
      * merge, No one is willing/available to give this test the time in needs */
-#ifndef TRAVIS_ENV
+#ifndef DISABLE_GROUP_TESTS
     DEFTESTCASE_SLOW(many_group, 80);
 #endif
 


### PR DESCRIPTION
They don't seem to be a lot less stable than the rest. Either way we regularly
need to restart builds to make timeouts go away.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/89)
<!-- Reviewable:end -->
