### PR TITLE
Remove unused DHT::secret_symmetric_key.

### DIFF
--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -2549,7 +2549,6 @@ DHT *new_DHT(Logger *log, Networking_Core *net)
     cryptopacket_registerhandler(dht, CRYPTO_PACKET_NAT_PING, &handle_NATping, dht);
     cryptopacket_registerhandler(dht, CRYPTO_PACKET_HARDENING, &handle_hardening, dht);
 
-    new_symmetric_key(dht->secret_symmetric_key);
     crypto_box_keypair(dht->self_public_key, dht->self_secret_key);
 
     ping_array_init(&dht->dht_ping_array, DHT_PING_ARRAY_SIZE, PING_TIMEOUT);

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -213,8 +213,6 @@ typedef struct {
     uint64_t       close_lastgetnodes;
     uint32_t       close_bootstrap_times;
 
-    /* Note: this key should not be/is not used to transmit any sensitive materials */
-    uint8_t      secret_symmetric_key[crypto_box_KEYBYTES];
     /* DHT keypair */
     uint8_t self_public_key[crypto_box_PUBLICKEYBYTES];
     uint8_t self_secret_key[crypto_box_SECRETKEYBYTES];


### PR DESCRIPTION
No idea what this was ever used for. It's a random 32 byte number used for
nothing at all now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/90)
<!-- Reviewable:end -->
