### PR TITLE
Improve C standard compliance.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -310,7 +310,7 @@ static uint8_t response_callback_connection_id;
 static uint8_t response_callback_public_key[crypto_box_PUBLICKEYBYTES];
 static int response_callback(void *object, uint8_t connection_id, const uint8_t *public_key)
 {
-    if (set_tcp_connection_number(object - 2, connection_id, 7) != 0) {
+    if (set_tcp_connection_number((TCP_Client_Connection *)((char *)object - 2), connection_id, 7) != 0) {
         return 1;
     }
 
@@ -433,7 +433,7 @@ START_TEST(test_client)
     crypto_box_keypair(f2_public_key, f2_secret_key);
     ip_port_tcp_s.port = htons(ports[rand() % NUM_PORTS]);
     TCP_Client_Connection *conn2 = new_TCP_connection(ip_port_tcp_s, self_public_key, f2_public_key, f2_secret_key, 0);
-    routing_response_handler(conn, response_callback, ((void *)conn) + 2);
+    routing_response_handler(conn, response_callback, (char *)conn + 2);
     routing_status_handler(conn, status_callback, (void *)2);
     routing_data_handler(conn, data_callback, (void *)3);
     oob_data_handler(conn, oob_data_callback, (void *)4);

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -694,7 +694,8 @@ START_TEST(test_few_clients)
 
     printf("Starting file transfer test.\n");
 
-    file_accepted = file_size = file_recv = sendf_ok = size_recv = 0;
+    file_accepted = file_size = sendf_ok = size_recv = 0;
+    file_recv = 0;
     max_sending = UINT64_MAX;
     long long unsigned int f_time = time(NULL);
     tox_callback_file_recv_chunk(tox3, write_file, &to_compare);
@@ -742,7 +743,8 @@ START_TEST(test_few_clients)
 
     printf("Starting file streaming transfer test.\n");
 
-    file_sending_done = file_accepted = file_size = file_recv = sendf_ok = size_recv = 0;
+    file_sending_done = file_accepted = file_size = sendf_ok = size_recv = 0;
+    file_recv = 0;
     tox_callback_file_recv_chunk(tox3, write_file, &to_compare);
     tox_callback_file_recv_control(tox2, file_print_control, &to_compare);
     tox_callback_file_chunk_request(tox2, tox_file_chunk_request, &to_compare);
@@ -788,7 +790,8 @@ START_TEST(test_few_clients)
 
     printf("Starting file 0 transfer test.\n");
 
-    file_sending_done = file_accepted = file_size = file_recv = sendf_ok = size_recv = 0;
+    file_sending_done = file_accepted = file_size = sendf_ok = size_recv = 0;
+    file_recv = 0;
     tox_callback_file_recv_chunk(tox3, write_file, &to_compare);
     tox_callback_file_recv_control(tox2, file_print_control, &to_compare);
     tox_callback_file_chunk_request(tox2, tox_file_chunk_request, &to_compare);

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -63,7 +63,7 @@ void t_toxav_call_cb(ToxAV *av, uint32_t friend_number, bool audio_enabled, bool
 }
 void t_toxav_call_state_cb(ToxAV *av, uint32_t friend_number, uint32_t state, void *user_data)
 {
-    printf("Handling CALL STATE callback: %d %p\n", state, av);
+    printf("Handling CALL STATE callback: %d %p\n", state, (void *)av);
     ((CallControl *)user_data)[friend_number].state = state;
 }
 void t_toxav_receive_video_frame_cb(ToxAV *av, uint32_t friend_number,
@@ -188,7 +188,7 @@ void *call_thread(void *pd)
         toxav_call_control(AliceAV, friend_number, TOXAV_CALL_CONTROL_CANCEL, &rc);
 
         if (rc != TOXAV_ERR_CALL_CONTROL_OK) {
-            printf("toxav_call_control failed: %d %p %p\n", rc, AliceAV, BobAV);
+            printf("toxav_call_control failed: %d %p %p\n", rc, (void *)AliceAV, (void *)BobAV);
         }
     }
 

--- a/other/DHT_bootstrap.c
+++ b/other/DHT_bootstrap.c
@@ -60,7 +60,7 @@
 
 void manage_keys(DHT *dht)
 {
-    const uint32_t KEYS_SIZE = crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
+    enum { KEYS_SIZE = crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES };
     uint8_t keys[KEYS_SIZE];
 
     FILE *keys_file = fopen("key", "r");

--- a/other/bootstrap_daemon/src/tox-bootstrapd.c
+++ b/other/bootstrap_daemon/src/tox-bootstrapd.c
@@ -50,12 +50,12 @@
 
 // Uses the already existing key or creates one if it didn't exist
 //
-// retirns 1 on success
+// returns 1 on success
 //         0 on failure - no keys were read or stored
 
 int manage_keys(DHT *dht, char *keys_file_path)
 {
-    const uint32_t KEYS_SIZE = crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES;
+    enum { KEYS_SIZE = crypto_box_PUBLICKEYBYTES + crypto_box_SECRETKEYBYTES };
     uint8_t keys[KEYS_SIZE];
     FILE *keys_file;
 

--- a/testing/dns3_test.c
+++ b/testing/dns3_test.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    uint8_t buffer[512] = {};
+    uint8_t buffer[512] = {0};
     int r_len = recv(sock, buffer, sizeof(buffer), 0);
 
     if (r_len < (int)p_len) {

--- a/testing/misc_tools.c
+++ b/testing/misc_tools.c
@@ -85,4 +85,4 @@ int cmdline_parsefor_ipv46(int argc, char **argv, uint8_t *ipv6enabled)
     }
 
     return argvoffset;
-};
+}

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -57,7 +57,7 @@ uint8_t flag[HISTORY];
 char input_line[STRING_LENGTH];
 
 /* wrap: continuation mark */
-const size_t wrap_cont_len = 3;
+enum { wrap_cont_len = 3 };
 const char wrap_cont_str[] = "\n+ ";
 
 #define STRING_LENGTH_WRAPPED (STRING_LENGTH + 16 * (wrap_cont_len + 1))

--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -37,21 +37,21 @@ enum {
 struct RTPHeader {
     /* Standard RTP header */
 #ifndef WORDS_BIGENDIAN
-    uint16_t cc: 4; /* Contributing sources count */
-    uint16_t xe: 1; /* Extra header */
-    uint16_t pe: 1; /* Padding */
-    uint16_t ve: 2; /* Version */
+    unsigned cc: 4; /* Contributing sources count */
+    unsigned xe: 1; /* Extra header */
+    unsigned pe: 1; /* Padding */
+    unsigned ve: 2; /* Version */
 
-    uint16_t pt: 7; /* Payload type */
-    uint16_t ma: 1; /* Marker */
+    unsigned pt: 7; /* Payload type */
+    unsigned ma: 1; /* Marker */
 #else
-    uint16_t ve: 2; /* Version */
-    uint16_t pe: 1; /* Padding */
-    uint16_t xe: 1; /* Extra header */
-    uint16_t cc: 4; /* Contributing sources count */
+    unsigned ve: 2; /* Version */
+    unsigned pe: 1; /* Padding */
+    unsigned xe: 1; /* Extra header */
+    unsigned cc: 4; /* Contributing sources count */
 
-    uint16_t ma: 1; /* Marker */
-    uint16_t pt: 7; /* Payload type */
+    unsigned ma: 1; /* Marker */
+    unsigned pt: 7; /* Payload type */
 #endif
 
     uint16_t sequnum;

--- a/toxcore/logger.h
+++ b/toxcore/logger.h
@@ -61,18 +61,18 @@ void logger_write(Logger *log, LOGGER_LEVEL level, const char *file, int line, c
                   ...);
 
 
-#define LOGGER_WRITE(log, level, format, ...) \
+#define LOGGER_WRITE(log, level, ...) \
     do { \
         if (level >= MIN_LOGGER_LEVEL) { \
-            logger_write(log, level, __FILE__, __LINE__, __func__, format, ##__VA_ARGS__); \
+            logger_write(log, level, __FILE__, __LINE__, __func__, __VA_ARGS__); \
         } \
     } while (0)
 
 /* To log with an logger */
-#define LOGGER_TRACE(log, format, ...)   LOGGER_WRITE(log, LOG_TRACE  , format, ##__VA_ARGS__)
-#define LOGGER_DEBUG(log, format, ...)   LOGGER_WRITE(log, LOG_DEBUG  , format, ##__VA_ARGS__)
-#define LOGGER_INFO(log, format, ...)    LOGGER_WRITE(log, LOG_INFO   , format, ##__VA_ARGS__)
-#define LOGGER_WARNING(log, format, ...) LOGGER_WRITE(log, LOG_WARNING, format, ##__VA_ARGS__)
-#define LOGGER_ERROR(log, format, ...)   LOGGER_WRITE(log, LOG_ERROR  , format, ##__VA_ARGS__)
+#define LOGGER_TRACE(log, ...)   LOGGER_WRITE(log, LOG_TRACE  , __VA_ARGS__)
+#define LOGGER_DEBUG(log, ...)   LOGGER_WRITE(log, LOG_DEBUG  , __VA_ARGS__)
+#define LOGGER_INFO(log, ...)    LOGGER_WRITE(log, LOG_INFO   , __VA_ARGS__)
+#define LOGGER_WARNING(log, ...) LOGGER_WRITE(log, LOG_WARNING, __VA_ARGS__)
+#define LOGGER_ERROR(log, ...)   LOGGER_WRITE(log, LOG_ERROR  , __VA_ARGS__)
 
 #endif /* TOXLOGGER_H */

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -155,7 +155,7 @@ IP6;
 
 typedef struct {
     uint8_t family;
-    union {
+    __extension__ union {
         IP4 ip4;
         IP6 ip6;
     };

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -169,7 +169,7 @@ int load_state(load_state_callback_func load_state_callback, void *outer,
     }
 
     return length == 0 ? 0 : -1;
-};
+}
 
 int create_recursive_mutex(pthread_mutex_t *mutex)
 {


### PR DESCRIPTION
- Don't cast between object and function pointers.
- Use standard compliant `__VA_ARGS__` in macros.
- Add explicit `__extension__` on unnamed union in struct (it's a GNU
  extension).
- Remove ; after function definitions.
- Replace `const T foo = 3;` for integral types `T` with `enum { foo = 3 };`.
  Folding integral constants like that as compile time constants is a GNU
  extension. Arrays allocated with `foo` as dimension are VLAs on strictly
  compliant C99 compilers.
- Replace empty initialiser list `{}` with zero-initialiser-list `{0}`.
  The former is a GNU extension meaning the latter.
- Cast `T*` (where `T != void`) to `void *` in format arguments. While any
  object pointer can be implicitly converted to and from `void *`, this
  conversion does not happen in variadic function calls.
- Replace arithmetic on `void *` with arithmetic on `char *`. The former
  is non-compliant.
- Replace non-`int`-derived types (like `uint16_t`, which is
  `short`-derived) in bit fields with `int`-derived types. Using any type
  other than `int` or `unsigned int` (or any of their aliases) in bit
  fields is a GNU extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/96)
<!-- Reviewable:end -->
