### PR TITLE
Make the const-cast in toxav less sneaky.

### DIFF
--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -177,7 +177,7 @@ void send_update(BWController *bwc)
         bwc->cycle.lsu = current_time_monotonic();
     }
 }
-int on_update (BWController *bwc, struct BWCMessage *msg)
+int on_update (BWController *bwc, const struct BWCMessage *msg)
 {
     LOGGER_DEBUG(bwc->m->log, "%p Got update from peer", bwc);
 
@@ -189,14 +189,20 @@ int on_update (BWController *bwc, struct BWCMessage *msg)
 
     bwc->cycle.lru = current_time_monotonic();
 
-    msg->recv = ntohl(msg->recv);
-    msg->lost = ntohl(msg->lost);
+    uint32_t recv = ntohl(msg->recv);
+    uint32_t lost = ntohl(msg->lost);
 
-    LOGGER_DEBUG(bwc->m->log, "recved: %u lost: %u", msg->recv, msg->lost);
+    /* NOTE the data is mutable. We're casting away the constness from the
+     * packet data here. This function is called only once for any given packet,
+     * so the mutation happens only once. */
+    ((struct BWCMessage *)msg)->recv = recv;
+    ((struct BWCMessage *)msg)->lost = lost;
 
-    if (msg->lost && bwc->mcb) {
+    LOGGER_DEBUG(bwc->m->log, "recved: %u lost: %u", recv, lost);
+
+    if (lost && bwc->mcb) {
         bwc->mcb(bwc, bwc->friend_number,
-                 ((float) (msg->lost) / (msg->recv + msg->lost)),
+                 ((float) lost / (recv + lost)),
                  bwc->mcb_data);
     }
 
@@ -208,6 +214,5 @@ int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, ui
         return -1;
     }
 
-    /* NOTE the data is mutable */
-    return on_update(object, (struct BWCMessage *) (data + 1));
+    return on_update(object, (const struct BWCMessage *) (data + 1));
 }


### PR DESCRIPTION
The toxav code casts away constness from the packet data and then
mutates it in-place. I don't know why it doesn't just copy the values,
but since there must be a reason (the data is somehow shared with other
code), I'm keeping it this way for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/98)
<!-- Reviewable:end -->
