### PR TITLE
Remove the packet mutation in toxav's bwcontroller.

### DIFF
--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -177,7 +177,7 @@ void send_update(BWController *bwc)
         bwc->cycle.lsu = current_time_monotonic();
     }
 }
-static int on_update (BWController *bwc, struct BWCMessage *msg)
+static int on_update (BWController *bwc, const struct BWCMessage *msg)
 {
     LOGGER_DEBUG(bwc->m->log, "%p Got update from peer", bwc);
 
@@ -189,14 +189,14 @@ static int on_update (BWController *bwc, struct BWCMessage *msg)
 
     bwc->cycle.lru = current_time_monotonic();
 
-    msg->recv = ntohl(msg->recv);
-    msg->lost = ntohl(msg->lost);
+    uint32_t recv = ntohl(msg->recv);
+    uint32_t lost = ntohl(msg->lost);
 
-    LOGGER_DEBUG(bwc->m->log, "recved: %u lost: %u", msg->recv, msg->lost);
+    LOGGER_DEBUG(bwc->m->log, "recved: %u lost: %u", recv, lost);
 
-    if (msg->lost && bwc->mcb) {
+    if (lost && bwc->mcb) {
         bwc->mcb(bwc, bwc->friend_number,
-                 ((float) (msg->lost) / (msg->recv + msg->lost)),
+                 ((float) lost / (recv + lost)),
                  bwc->mcb_data);
     }
 
@@ -208,6 +208,5 @@ int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, ui
         return -1;
     }
 
-    /* NOTE the data is mutable */
-    return on_update(object, (struct BWCMessage *) (data + 1));
+    return on_update(object, (const struct BWCMessage *) (data + 1));
 }


### PR DESCRIPTION
1. This mutation is never observed outside the function.
2. If it were (it's not), it would be undefined behaviour, since the
   packet data goes out of scope a few instructions after the callback
   returns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/100)
<!-- Reviewable:end -->
