### PR TITLE
Allocate sizeof(IP_ADAPTER_INFO) bytes instead of sizeof(T*).

### DIFF
--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -49,8 +49,8 @@ static void fetch_broadcast_info(uint16_t port)
 {
     broadcast_count = 0;
 
-    IP_ADAPTER_INFO *pAdapterInfo = malloc(sizeof(pAdapterInfo));
-    unsigned long ulOutBufLen = sizeof(pAdapterInfo);
+    IP_ADAPTER_INFO *pAdapterInfo = malloc(sizeof(IP_ADAPTER_INFO));
+    unsigned long ulOutBufLen = sizeof(IP_ADAPTER_INFO);
 
     if (pAdapterInfo == NULL) {
         return;


### PR DESCRIPTION
https://msdn.microsoft.com/en-gb/library/windows/desktop/aa365917(v=vs.85).aspx
shows an example use of GetAdaptersInfo that does it this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/103)
<!-- Reviewable:end -->
