### PR TITLE
Fix compilation for Windows.

### DIFF
--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -37,21 +37,21 @@ enum {
 struct RTPHeader {
     /* Standard RTP header */
 #ifndef WORDS_BIGENDIAN
-    unsigned cc: 4; /* Contributing sources count */
-    unsigned xe: 1; /* Extra header */
-    unsigned pe: 1; /* Padding */
-    unsigned ve: 2; /* Version */
+    uint16_t cc: 4; /* Contributing sources count */
+    uint16_t xe: 1; /* Extra header */
+    uint16_t pe: 1; /* Padding */
+    uint16_t ve: 2; /* Version */
 
-    unsigned pt: 7; /* Payload type */
-    unsigned ma: 1; /* Marker */
+    uint16_t pt: 7; /* Payload type */
+    uint16_t ma: 1; /* Marker */
 #else
-    unsigned ve: 2; /* Version */
-    unsigned pe: 1; /* Padding */
-    unsigned xe: 1; /* Extra header */
-    unsigned cc: 4; /* Contributing sources count */
+    uint16_t ve: 2; /* Version */
+    uint16_t pe: 1; /* Padding */
+    uint16_t xe: 1; /* Extra header */
+    uint16_t cc: 4; /* Contributing sources count */
 
-    unsigned ma: 1; /* Marker */
-    unsigned pt: 7; /* Payload type */
+    uint16_t ma: 1; /* Marker */
+    uint16_t pt: 7; /* Payload type */
 #endif
 
     uint16_t sequnum;

--- a/toxcore/network.h
+++ b/toxcore/network.h
@@ -44,15 +44,12 @@
 #define WINVER 0x0501
 #endif
 
-// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms737629(v=vs.85).aspx
-// for why. In short: we need to avoid inclusion of <winsock.h> by <windows.h>,
-// so <winsock2.h> doesn't cause issues.
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
+// The mingw32/64 Windows library warns about including winsock2.h after
+// windows.h even though with the above it's a valid thing to do. So, to make
+// mingw32 headers happy, we include winsock2.h first.
+#include <winsock2.h>
 
 #include <windows.h>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #ifndef IPV6_V6ONLY


### PR DESCRIPTION
- Mingw32 didn't read MSDN, so behaves badly despite lean and mean.
- Avoid alignment issues on windows with packed bitfields in the RTP header.
  This change makes the program ill-formed in C99, but I don't know the correct
  fix at the moment, and I don't want to keep the Windows build broken for too
  long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/114)
<!-- Reviewable:end -->
