### PR TITLE
Add STRICT_ABI cmake flag to generate export lists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,3 +372,39 @@ if(BUILD_TOXAV)
     toxav/toxav.h
     DESTINATION "include/tox")
 endif()
+
+################################################################################
+#
+# :: Strict ABI
+#
+################################################################################
+
+function(make_version_script header ns lib)
+  execute_process(
+    COMMAND sh -c "egrep '^\\w' ${header} | grep '${ns}_[a-z_]*(' | grep -v '^typedef' | grep -o '${ns}_[a-z_]*(' | egrep -o '\\w+' | sort -u"
+    OUTPUT_VARIABLE ${lib}_SYMS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" ${lib}_SYMS ${${lib}_SYMS})
+
+  set(${lib}_VERSION_SCRIPT "${CMAKE_BINARY_DIR}/${lib}.ld")
+
+  file(WRITE ${${lib}_VERSION_SCRIPT}
+    "{ global:\n")
+  foreach(sym ${${lib}_SYMS})
+    file(APPEND ${${lib}_VERSION_SCRIPT}
+      "${sym};\n")
+  endforeach(sym)
+  file(APPEND ${${lib}_VERSION_SCRIPT}
+    "local: *; };\n")
+
+  set_target_properties(${lib}_shared PROPERTIES
+    LINK_FLAGS -Wl,--version-script,${${lib}_VERSION_SCRIPT})
+endfunction()
+
+option(STRICT_ABI "Enforce strict ABI export in dynamic libraries" OFF)
+if(STRICT_ABI)
+  if(BUILD_TOXAV)
+    make_version_script(${CMAKE_SOURCE_DIR}/toxav/toxav.h toxav toxav)
+  endif()
+  make_version_script(${CMAKE_SOURCE_DIR}/toxcore/tox.h tox toxcore)
+endif()

--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -6,7 +6,7 @@ export CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
 # Build toxcore and run tests.
 # TODO(iphydf): Enable ASAN. It currently has some bad interactions with gcov,
 # so it's disabled on Travis.
-RUN $CMAKE -B$BUILD_DIR -H. -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install -DDEBUG=ON -DASSOC_DHT=ON #-DASAN=ON
+RUN $CMAKE -B$BUILD_DIR -H. -DCMAKE_INSTALL_PREFIX:PATH=$CURDIR/_install -DDEBUG=ON -DASSOC_DHT=ON -DSTRICT_ABI=ON #-DASAN=ON
 
 RUN make -C $BUILD_DIR -j$NPROC -k install
 


### PR DESCRIPTION
Enabling this flag will generate and use an LD version script. It
ensures that the dynamic libraries (libtoxcore.so, libtoxav.so) only
export the symbols that are defined in their public API (tox.h and
toxav.h, respectively).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/117)
<!-- Reviewable:end -->
