### PR TITLE
Add some astyle options to make it do more.

### DIFF
--- a/auto_tests/dht_test.c
+++ b/auto_tests/dht_test.c
@@ -334,14 +334,16 @@ static void test_addto_lists(IP ip)
      * to replace the first ip by the second. */
     test_addto_lists_update(dht, dht->close_clientlist, LCLIENT_LIST, &ip_port);
 
-    for (i = 0; i < dht->num_friends; ++i)
+    for (i = 0; i < dht->num_friends; ++i) {
         test_addto_lists_update(dht, dht->friends_list[i].client_list, MAX_FRIEND_CLIENTS, &ip_port);
+    }
 
     // check "bad" entries
     test_addto_lists_bad(dht, dht->close_clientlist, LCLIENT_LIST, &ip_port);
 
-    for (i = 0; i < dht->num_friends; ++i)
+    for (i = 0; i < dht->num_friends; ++i) {
         test_addto_lists_bad(dht, dht->friends_list[i].client_list, MAX_FRIEND_CLIENTS, &ip_port);
+    }
 
     // check "possibly bad" entries
     /*

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -94,7 +94,8 @@ static void print_status_m_change(Tox *tox, uint32_t friend_number, const uint8_
         return;
     }
 
-    if (length == sizeof("Installing Gentoo") && memcmp(message, "Installing Gentoo", sizeof("Installing Gentoo")) == 0) {
+    if (length == sizeof("Installing Gentoo") &&
+            memcmp(message, "Installing Gentoo", sizeof("Installing Gentoo")) == 0) {
         ++status_m_changes;
     }
 }

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -200,7 +200,7 @@ static void *call_thread(void *pd)
     free(video_u);
     free(video_v);
 
-    printf ("Closing thread\n");
+    printf("Closing thread\n");
     pthread_exit(NULL);
 }
 
@@ -326,7 +326,7 @@ START_TEST(test_AV_three_calls)
     (void) pthread_join(tids[1], NULL);
     (void) pthread_join(tids[2], NULL);
 
-    printf ("Killing all instances\n");
+    printf("Killing all instances\n");
     toxav_kill(BobsAV[0]);
     toxav_kill(BobsAV[1]);
     toxav_kill(BobsAV[2]);

--- a/other/astyle/astylerc
+++ b/other/astyle/astylerc
@@ -1,11 +1,26 @@
+# Bracket Style Options
 --style=kr
-        --pad-header
-        --max-code-length=120
-                          --convert-tabs
-                          --indent-switches
-                          --pad-oper
-                          --align-pointer=name
-                                  --align-reference=name
-                                          --preserve-date
-                                          --lineend=linux
-                                                  --break-blocks
+
+# Tab Options
+--indent=spaces=4
+
+# Indentation Options
+--indent-switches
+
+# Padding Options
+--pad-header
+--break-blocks
+--pad-oper
+--unpad-paren
+--align-pointer=name
+--align-reference=name
+
+# Formatting Options
+--add-brackets
+--convert-tabs
+--max-code-length=120
+
+# Other Options
+--preserve-date
+--formatted
+--lineend=linux

--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -87,7 +87,7 @@ static void print_request(Messenger *m, const uint8_t *public_key, const uint8_t
         return;
     }
 
-    if (memcmp(data , "Install Gentoo", sizeof("Install Gentoo")) == 0 )
+    if (memcmp(data , "Install Gentoo", sizeof("Install Gentoo")) == 0)
         //if the request contained the message of peace the person is obviously a friend so we add him.
     {
         printf("Friend request accepted.\n");
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     options.ipv6enabled = ipv6enabled;
     m = new_messenger(NULL, &options, 0);
 
-    if ( !m ) {
+    if (!m) {
         fputs("Failed to allocate messenger datastructure\n", stderr);
         exit(0);
     }
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
     } else {
         FILE *file = fopen(argv[argvoffset + 1], "rb");
 
-        if ( file == NULL ) {
+        if (file == NULL) {
             printf("Failed to open \"%s\" - does it exist?\n", argv[argvoffset + 1]);
             return 1;
         }
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
         c_sleep(30);
         FILE *file = fopen("Save.bak", "wb");
 
-        if ( file == NULL ) {
+        if (file == NULL) {
             return 1;
         }
 

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -92,7 +92,7 @@ typedef struct {
     int16_t data[];
 } frame;
 
-static void *pa_write_thread (void *d)
+static void *pa_write_thread(void *d)
 {
     /* The purpose of this thread is to make sure Pa_WriteStream will not block
      * toxav_iterate thread
@@ -186,7 +186,7 @@ static void t_toxav_bit_rate_status_cb(ToxAV *av, uint32_t friend_number,
                                        uint32_t audio_bit_rate, uint32_t video_bit_rate,
                                        void *user_data)
 {
-    printf ("Suggested bit rates: audio: %d video: %d\n", audio_bit_rate, video_bit_rate);
+    printf("Suggested bit rates: audio: %d video: %d\n", audio_bit_rate, video_bit_rate);
 }
 static void t_accept_friend_request_cb(Tox *m, const uint8_t *public_key, const uint8_t *data, size_t length,
                                        void *userdata)
@@ -295,7 +295,7 @@ static int iterate_tox(Tox *bootstrap, ToxAV *AliceAV, ToxAV *BobAV, void *userd
 
     return MIN(tox_iteration_interval(toxav_get_tox(AliceAV)), tox_iteration_interval(toxav_get_tox(BobAV)));
 }
-static void *iterate_toxav (void *data)
+static void *iterate_toxav(void *data)
 {
     struct toxav_thread_data *data_cast = data;
 #if defined TEST_TRANSFER_V && TEST_TRANSFER_V == 1
@@ -383,7 +383,7 @@ static int print_audio_devices(void)
 
     return 0;
 }
-static int print_help (const char *name)
+static int print_help(const char *name)
 {
     printf("Usage: %s -[a:v:o:dh]\n"
            "-a <path> audio input file\n"
@@ -397,7 +397,7 @@ static int print_help (const char *name)
     return 0;
 }
 
-int main (int argc, char **argv)
+int main(int argc, char **argv)
 {
     freopen("/dev/zero", "w", stderr);
     Pa_Initialize();
@@ -615,7 +615,7 @@ CHECK_ARG:
 
         printf("Sample rate %d\n", af_info.samplerate);
 
-        while (start_time + expected_time > time(NULL) ) {
+        while (start_time + expected_time > time(NULL)) {
             uint64_t enc_start_time = current_time_monotonic();
             int64_t count = sf_read_short(af_handle, PCM, frame_size);
 
@@ -728,7 +728,7 @@ CHECK_ARG:
         time_t start_time = time(NULL);
 
         while (start_time + 90 > time(NULL)) {
-            IplImage *frame = cvQueryFrame(capture );
+            IplImage *frame = cvQueryFrame(capture);
 
             if (!frame) {
                 break;

--- a/testing/irc_syncbot.c
+++ b/testing/irc_syncbot.c
@@ -250,7 +250,7 @@ static Tox *init_tox(int argc, char *argv[])
     printf("\nEnter the address of irc_syncbots master (38 bytes HEX format):\n");
 
     if (scanf("%s", temp_id) != 1) {
-        exit (1);
+        exit(1);
     }
 
     uint16_t port = atoi(argv[argvoffset + 2]);
@@ -351,10 +351,10 @@ int main(int argc, char *argv[])
         }
 
         int error = 0;
-        socklen_t len = sizeof (error);
+        socklen_t len = sizeof(error);
 
         if (sock < 0 || last_get + SILENT_TIMEOUT < get_monotime_sec()
-                || getsockopt(sock, SOL_SOCKET, SO_ERROR, &error, &len ) != 0) {
+                || getsockopt(sock, SOL_SOCKET, SO_ERROR, &error, &len) != 0) {
             close(sock);
             printf("reconnect\n");
             sock = reconnect();

--- a/testing/nTox.c
+++ b/testing/nTox.c
@@ -302,8 +302,8 @@ static void print_formatted_message(Tox *m, char *message, int friendnum, uint8_
 
     time_t rawtime;
     struct tm *timeinfo;
-    time ( &rawtime );
-    timeinfo = localtime ( &rawtime );
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
 
     /* assume that printing the date once a day is enough */
     if (fmtmsg_tm_mday != timeinfo->tm_mday) {
@@ -1332,7 +1332,7 @@ int main(int argc, char *argv[])
     data_file_name = filename;
     m = load_data();
 
-    if ( !m ) {
+    if (!m) {
         fputs("Failed to allocate Messenger datastructure", stderr);
         exit(0);
     }

--- a/toxav/audio.c
+++ b/toxav/audio.c
@@ -36,7 +36,7 @@ static void jbuf_clear(struct JitterBuffer *q);
 static void jbuf_free(struct JitterBuffer *q);
 static int jbuf_write(Logger *log, struct JitterBuffer *q, struct RTPMessage *m);
 static struct RTPMessage *jbuf_read(struct JitterBuffer *q, int32_t *success);
-OpusEncoder *create_audio_encoder (Logger *log, int32_t bit_rate, int32_t sampling_rate, int32_t channel_count);
+OpusEncoder *create_audio_encoder(Logger *log, int32_t bit_rate, int32_t sampling_rate, int32_t channel_count);
 bool reconfigure_audio_encoder(Logger *log, OpusEncoder **e, int32_t new_br, int32_t new_sr, uint8_t new_ch,
                                int32_t *old_br, int32_t *old_sr, int32_t *old_ch);
 bool reconfigure_audio_decoder(ACSession *ac, int32_t sampling_rate, int8_t channels);
@@ -349,7 +349,7 @@ static struct RTPMessage *jbuf_read(struct JitterBuffer *q, int32_t *success)
     *success = 0;
     return NULL;
 }
-OpusEncoder *create_audio_encoder (Logger *log, int32_t bit_rate, int32_t sampling_rate, int32_t channel_count)
+OpusEncoder *create_audio_encoder(Logger *log, int32_t bit_rate, int32_t sampling_rate, int32_t channel_count)
 {
     int status = OPUS_OK;
     OpusEncoder *rc = opus_encoder_create(sampling_rate, channel_count, OPUS_APPLICATION_VOIP, &status);

--- a/toxav/bwcontroller.c
+++ b/toxav/bwcontroller.c
@@ -40,7 +40,7 @@
  */
 
 struct BWController_s {
-    void (*mcb) (BWController *, uint32_t, float, void *);
+    void (*mcb)(BWController *, uint32_t, float, void *);
     void *mcb_data;
 
     Messenger *m;
@@ -65,7 +65,7 @@ int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, ui
 void send_update(BWController *bwc);
 
 BWController *bwc_new(Messenger *m, uint32_t friendnumber,
-                      void (*mcb) (BWController *, uint32_t, float, void *),
+                      void (*mcb)(BWController *, uint32_t, float, void *),
                       void *udata)
 {
     BWController *retu = calloc(sizeof(struct BWController_s), 1);
@@ -179,7 +179,7 @@ void send_update(BWController *bwc)
         bwc->cycle.lsu = current_time_monotonic();
     }
 }
-static int on_update (BWController *bwc, const struct BWCMessage *msg)
+static int on_update(BWController *bwc, const struct BWCMessage *msg)
 {
     LOGGER_DEBUG(bwc->m->log, "%p Got update from peer", bwc);
 
@@ -210,5 +210,5 @@ int bwc_handle_data(Messenger *m, uint32_t friendnumber, const uint8_t *data, ui
         return -1;
     }
 
-    return on_update(object, (const struct BWCMessage *) (data + 1));
+    return on_update(object, (const struct BWCMessage *)(data + 1));
 }

--- a/toxav/bwcontroller.h
+++ b/toxav/bwcontroller.h
@@ -27,7 +27,7 @@
 typedef struct BWController_s BWController;
 
 BWController *bwc_new(Messenger *m, uint32_t friendnumber,
-                      void (*mcb) (BWController *, uint32_t, float, void *),
+                      void (*mcb)(BWController *, uint32_t, float, void *),
                       void *udata);
 void bwc_kill(BWController *bwc);
 

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -64,9 +64,9 @@ typedef struct { \
 } MSIHeader##header
 
 
-GENERIC_HEADER (Request, MSIRequest);
-GENERIC_HEADER (Error, MSIError);
-GENERIC_HEADER (Capabilities, uint8_t);
+GENERIC_HEADER(Request, MSIRequest);
+GENERIC_HEADER(Error, MSIError);
+GENERIC_HEADER(Capabilities, uint8_t);
 
 
 typedef struct {
@@ -76,26 +76,26 @@ typedef struct {
 } MSIMessage;
 
 
-void msg_init (MSIMessage *dest, MSIRequest request);
-int msg_parse_in (Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length);
-uint8_t *msg_parse_header_out (MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len, uint16_t *length);
-static int send_message (Messenger *m, uint32_t friend_number, const MSIMessage *msg);
-int send_error (Messenger *m, uint32_t friend_number, MSIError error);
+void msg_init(MSIMessage *dest, MSIRequest request);
+int msg_parse_in(Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length);
+uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len, uint16_t *length);
+static int send_message(Messenger *m, uint32_t friend_number, const MSIMessage *msg);
+int send_error(Messenger *m, uint32_t friend_number, MSIError error);
 static int invoke_callback(MSICall *call, MSICallbackID cb);
-static MSICall *get_call (MSISession *session, uint32_t friend_number);
-MSICall *new_call (MSISession *session, uint32_t friend_number);
-void kill_call (MSICall *call);
+static MSICall *get_call(MSISession *session, uint32_t friend_number);
+MSICall *new_call(MSISession *session, uint32_t friend_number);
+void kill_call(MSICall *call);
 void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *data);
-void handle_init (MSICall *call, const MSIMessage *msg);
-void handle_push (MSICall *call, const MSIMessage *msg);
-void handle_pop (MSICall *call, const MSIMessage *msg);
-void handle_msi_packet (Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object);
+void handle_init(MSICall *call, const MSIMessage *msg);
+void handle_push(MSICall *call, const MSIMessage *msg);
+void handle_pop(MSICall *call, const MSIMessage *msg);
+void handle_msi_packet(Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object);
 
 
 /**
  * Public functions
  */
-void msi_register_callback (MSISession *session, msi_action_cb *callback, MSICallbackID id)
+void msi_register_callback(MSISession *session, msi_action_cb *callback, MSICallbackID id)
 {
     if (!session) {
         return;
@@ -105,13 +105,13 @@ void msi_register_callback (MSISession *session, msi_action_cb *callback, MSICal
     session->callbacks[id] = callback;
     pthread_mutex_unlock(session->mutex);
 }
-MSISession *msi_new (Messenger *m)
+MSISession *msi_new(Messenger *m)
 {
     if (m == NULL) {
         return NULL;
     }
 
-    MSISession *retu = calloc (sizeof (MSISession), 1);
+    MSISession *retu = calloc(sizeof(MSISession), 1);
 
     if (retu == NULL) {
         LOGGER_ERROR(m->log, "Allocation failed! Program might misbehave!");
@@ -134,7 +134,7 @@ MSISession *msi_new (Messenger *m)
     LOGGER_DEBUG(m->log, "New msi session: %p ", retu);
     return retu;
 }
-int msi_kill (MSISession *session)
+int msi_kill(MSISession *session)
 {
     if (session == NULL) {
         LOGGER_ERROR(session->messenger->log, "Tried to terminate non-existing session");
@@ -166,10 +166,10 @@ int msi_kill (MSISession *session)
     pthread_mutex_destroy(session->mutex);
 
     LOGGER_DEBUG(session->messenger->log, "Terminated session: %p", session);
-    free (session);
+    free(session);
     return 0;
 }
-int msi_invite (MSISession *session, MSICall **call, uint32_t friend_number, uint8_t capabilities)
+int msi_invite(MSISession *session, MSICall **call, uint32_t friend_number, uint8_t capabilities)
 {
     if (!session) {
         return -1;
@@ -188,7 +188,7 @@ int msi_invite (MSISession *session, MSICall **call, uint32_t friend_number, uin
         return -1;
     }
 
-    (*call) = new_call (session, friend_number);
+    (*call) = new_call(session, friend_number);
 
     if (*call == NULL) {
         pthread_mutex_unlock(session->mutex);
@@ -203,7 +203,7 @@ int msi_invite (MSISession *session, MSICall **call, uint32_t friend_number, uin
     msg.capabilities.exists = true;
     msg.capabilities.value = capabilities;
 
-    send_message ((*call)->session->messenger, (*call)->friend_number, &msg);
+    send_message((*call)->session->messenger, (*call)->friend_number, &msg);
 
     (*call)->state = msi_CallRequesting;
 
@@ -211,7 +211,7 @@ int msi_invite (MSISession *session, MSICall **call, uint32_t friend_number, uin
     pthread_mutex_unlock(session->mutex);
     return 0;
 }
-int msi_hangup (MSICall *call)
+int msi_hangup(MSICall *call)
 {
     if (!call || !call->session) {
         return -1;
@@ -236,13 +236,13 @@ int msi_hangup (MSICall *call)
     MSIMessage msg;
     msg_init(&msg, requ_pop);
 
-    send_message (session->messenger, call->friend_number, &msg);
+    send_message(session->messenger, call->friend_number, &msg);
 
     kill_call(call);
     pthread_mutex_unlock(session->mutex);
     return 0;
 }
-int msi_answer (MSICall *call, uint8_t capabilities)
+int msi_answer(MSICall *call, uint8_t capabilities)
 {
     if (!call || !call->session) {
         return -1;
@@ -273,7 +273,7 @@ int msi_answer (MSICall *call, uint8_t capabilities)
     msg.capabilities.exists = true;
     msg.capabilities.value = capabilities;
 
-    send_message (session->messenger, call->friend_number, &msg);
+    send_message(session->messenger, call->friend_number, &msg);
 
     call->state = msi_CallActive;
     pthread_mutex_unlock(session->mutex);
@@ -310,7 +310,7 @@ int msi_change_capabilities(MSICall *call, uint8_t capabilities)
     msg.capabilities.exists = true;
     msg.capabilities.value = capabilities;
 
-    send_message (call->session->messenger, call->friend_number, &msg);
+    send_message(call->session->messenger, call->friend_number, &msg);
 
     pthread_mutex_unlock(session->mutex);
     return 0;
@@ -326,7 +326,7 @@ void msg_init(MSIMessage *dest, MSIRequest request)
     dest->request.exists = true;
     dest->request.value = request;
 }
-int msg_parse_in (Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length)
+int msg_parse_in(Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t length)
 {
     /* Parse raw data received from socket into MSIMessage struct */
 
@@ -400,7 +400,7 @@ int msg_parse_in (Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t l
 #undef SET_UINT8
 #undef SET_UINT16
 }
-uint8_t *msg_parse_header_out (MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len, uint16_t *length)
+uint8_t *msg_parse_header_out(MSIHeaderID id, uint8_t *dest, const void *value, uint8_t value_len, uint16_t *length)
 {
     /* Parse a single header for sending */
     assert(dest);
@@ -418,7 +418,7 @@ uint8_t *msg_parse_header_out (MSIHeaderID id, uint8_t *dest, const void *value,
 
     return dest + value_len; /* Set to next position ready to be written */
 }
-int send_message (Messenger *m, uint32_t friend_number, const MSIMessage *msg)
+int send_message(Messenger *m, uint32_t friend_number, const MSIMessage *msg)
 {
     /* Parse and send message */
     assert(m);
@@ -463,7 +463,7 @@ int send_message (Messenger *m, uint32_t friend_number, const MSIMessage *msg)
 
     return -1;
 }
-int send_error (Messenger *m, uint32_t friend_number, MSIError error)
+int send_error(Messenger *m, uint32_t friend_number, MSIError error)
 {
     /* Send error message */
     assert(m);
@@ -476,7 +476,7 @@ int send_error (Messenger *m, uint32_t friend_number, MSIError error)
     msg.error.exists = true;
     msg.error.value = error;
 
-    send_message (m, friend_number, &msg);
+    send_message(m, friend_number, &msg);
     return 0;
 }
 int invoke_callback(MSICall *call, MSICallbackID cb)
@@ -486,7 +486,7 @@ int invoke_callback(MSICall *call, MSICallbackID cb)
     if (call->session->callbacks[cb]) {
         LOGGER_DEBUG(call->session->messenger->log, "Invoking callback function: %d", cb);
 
-        if (call->session->callbacks[cb] (call->session->av, call) != 0) {
+        if (call->session->callbacks[cb](call->session->av, call) != 0) {
             LOGGER_WARNING(call->session->messenger->log,
                            "Callback state handling failed, sending error");
             goto FAILURE;
@@ -506,7 +506,7 @@ FAILURE:
 
     return -1;
 }
-static MSICall *get_call (MSISession *session, uint32_t friend_number)
+static MSICall *get_call(MSISession *session, uint32_t friend_number)
 {
     assert(session);
 
@@ -516,7 +516,7 @@ static MSICall *get_call (MSISession *session, uint32_t friend_number)
 
     return session->calls[friend_number];
 }
-MSICall *new_call (MSISession *session, uint32_t friend_number)
+MSICall *new_call(MSISession *session, uint32_t friend_number)
 {
     assert(session);
 
@@ -530,7 +530,7 @@ MSICall *new_call (MSISession *session, uint32_t friend_number)
     rc->friend_number = friend_number;
 
     if (session->calls == NULL) { /* Creating */
-        session->calls = calloc (sizeof(MSICall *), friend_number + 1);
+        session->calls = calloc(sizeof(MSICall *), friend_number + 1);
 
         if (session->calls == NULL) {
             free(rc);
@@ -568,7 +568,7 @@ MSICall *new_call (MSISession *session, uint32_t friend_number)
     session->calls[friend_number] = rc;
     return rc;
 }
-void kill_call (MSICall *call)
+void kill_call(MSICall *call)
 {
     /* Assume that session mutex is locked */
     if (call == NULL) {
@@ -635,7 +635,7 @@ void on_peer_status(Messenger *m, uint32_t friend_number, uint8_t status, void *
             break;
     }
 }
-void handle_init (MSICall *call, const MSIMessage *msg)
+void handle_init(MSICall *call, const MSIMessage *msg)
 {
     assert(call);
     LOGGER_DEBUG(call->session->messenger->log,
@@ -675,7 +675,7 @@ void handle_init (MSICall *call, const MSIMessage *msg)
             msg.capabilities.exists = true;
             msg.capabilities.value = call->self_capabilities;
 
-            send_message (call->session->messenger, call->friend_number, &msg);
+            send_message(call->session->messenger, call->friend_number, &msg);
 
             /* If peer changed capabilities during re-call they will
              * be handled accordingly during the next step
@@ -697,7 +697,7 @@ FAILURE:
     send_error(call->session->messenger, call->friend_number, call->error);
     kill_call(call);
 }
-void handle_push (MSICall *call, const MSIMessage *msg)
+void handle_push(MSICall *call, const MSIMessage *msg)
 {
     assert(call);
 
@@ -752,7 +752,7 @@ FAILURE:
     send_error(call->session->messenger, call->friend_number, call->error);
     kill_call(call);
 }
-void handle_pop (MSICall *call, const MSIMessage *msg)
+void handle_pop(MSICall *call, const MSIMessage *msg)
 {
     assert(call);
 
@@ -796,16 +796,16 @@ void handle_pop (MSICall *call, const MSIMessage *msg)
         }
     }
 
-    kill_call (call);
+    kill_call(call);
 }
-void handle_msi_packet (Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object)
+void handle_msi_packet(Messenger *m, uint32_t friend_number, const uint8_t *data, uint16_t length, void *object)
 {
     LOGGER_DEBUG(m->log, "Got msi message");
 
     MSISession *session = object;
     MSIMessage msg;
 
-    if (msg_parse_in (m->log, &msg, data, length) == -1) {
+    if (msg_parse_in(m->log, &msg, data, length) == -1) {
         LOGGER_WARNING(m->log, "Error parsing message");
         send_error(m, friend_number, msi_EInvalidMessage);
         return;

--- a/toxav/msi.h
+++ b/toxav/msi.h
@@ -102,7 +102,7 @@ typedef struct MSICall_s {
  * returned the call is considered errored and will be handled
  * as such which means it will be terminated without any notice.
  */
-typedef int msi_action_cb (void *av, MSICall *call);
+typedef int msi_action_cb(void *av, MSICall *call);
 
 /**
  * Control session struct. Please do not modify outside msi.c

--- a/toxav/rtp.c
+++ b/toxav/rtp.c
@@ -35,12 +35,12 @@
 #include <stdlib.h>
 
 
-int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object);
+int handle_rtp_packet(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object);
 
 
-RTPSession *rtp_new (int payload_type, Messenger *m, uint32_t friendnumber,
-                     BWController *bwc, void *cs,
-                     int (*mcb) (void *, struct RTPMessage *))
+RTPSession *rtp_new(int payload_type, Messenger *m, uint32_t friendnumber,
+                    BWController *bwc, void *cs,
+                    int (*mcb)(void *, struct RTPMessage *))
 {
     assert(mcb);
     assert(cs);
@@ -73,7 +73,7 @@ RTPSession *rtp_new (int payload_type, Messenger *m, uint32_t friendnumber,
 
     return retu;
 }
-void rtp_kill (RTPSession *session)
+void rtp_kill(RTPSession *session)
 {
     if (!session) {
         return;
@@ -81,8 +81,8 @@ void rtp_kill (RTPSession *session)
 
     LOGGER_DEBUG(session->m->log, "Terminated RTP session: %p", session);
 
-    rtp_stop_receiving (session);
-    free (session);
+    rtp_stop_receiving(session);
+    free(session);
 }
 int rtp_allow_receiving(RTPSession *session)
 {
@@ -110,7 +110,7 @@ int rtp_stop_receiving(RTPSession *session)
     LOGGER_DEBUG(session->m->log, "Stopped receiving on session: %p", session);
     return 0;
 }
-int rtp_send_data (RTPSession *session, const uint8_t *data, uint16_t length)
+int rtp_send_data(RTPSession *session, const uint8_t *data, uint16_t length)
 {
     if (!session) {
         LOGGER_WARNING(session->m->log, "No session!");
@@ -193,7 +193,7 @@ int rtp_send_data (RTPSession *session, const uint8_t *data, uint16_t length)
 }
 
 
-static bool chloss (const RTPSession *session, const struct RTPHeader *header)
+static bool chloss(const RTPSession *session, const struct RTPHeader *header)
 {
     if (ntohl(header->timestamp) < session->rtimestamp) {
         uint16_t hosq, lost = 0;
@@ -204,7 +204,7 @@ static bool chloss (const RTPSession *session, const struct RTPHeader *header)
                (session->rsequnum + 65535) - hosq :
                session->rsequnum - hosq;
 
-        fprintf (stderr, "Lost packet\n");
+        fprintf(stderr, "Lost packet\n");
 
         while (lost --) {
             bwc_add_lost(session->bwc , 0);
@@ -215,7 +215,7 @@ static bool chloss (const RTPSession *session, const struct RTPHeader *header)
 
     return false;
 }
-static struct RTPMessage *new_message (size_t allocate_len, const uint8_t *data, uint16_t data_length)
+static struct RTPMessage *new_message(size_t allocate_len, const uint8_t *data, uint16_t data_length)
 {
     assert(allocate_len >= data_length);
 
@@ -233,7 +233,7 @@ static struct RTPMessage *new_message (size_t allocate_len, const uint8_t *data,
 
     return msg;
 }
-int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object)
+int handle_rtp_packet(Messenger *m, uint32_t friendnumber, const uint8_t *data, uint16_t length, void *object)
 {
     (void) m;
     (void) friendnumber;
@@ -243,7 +243,7 @@ int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data,
     data ++;
     length--;
 
-    if (!session || length < sizeof (struct RTPHeader)) {
+    if (!session || length < sizeof(struct RTPHeader)) {
         LOGGER_WARNING(m->log, "No session or invalid length of received buffer!");
         return -1;
     }
@@ -262,7 +262,7 @@ int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data,
 
     bwc_feed_avg(session->bwc, length);
 
-    if (ntohs(header->tlen) == length - sizeof (struct RTPHeader)) {
+    if (ntohs(header->tlen) == length - sizeof(struct RTPHeader)) {
         /* The message is sent in single part */
 
         /* Only allow messages which have arrived in order;
@@ -281,7 +281,7 @@ int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data,
         /* Invoke processing of active multiparted message */
         if (session->mp) {
             if (session->mcb) {
-                session->mcb (session->cs, session->mp);
+                session->mcb(session->cs, session->mp);
             } else {
                 free(session->mp);
             }
@@ -297,7 +297,7 @@ int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data,
             return 0;
         }
 
-        return session->mcb (session->cs, new_message(length, data, length));
+        return session->mcb(session->cs, new_message(length, data, length));
     }
 
     /* The message is sent in multiple parts */
@@ -336,7 +336,7 @@ int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data,
                  * processing.
                  */
                 if (session->mcb) {
-                    session->mcb (session->cs, session->mp);
+                    session->mcb(session->cs, session->mp);
                 } else {
                     free(session->mp);
                 }
@@ -359,11 +359,11 @@ int handle_rtp_packet (Messenger *m, uint32_t friendnumber, const uint8_t *data,
 
                          /* Must account sizes of rtp headers too */
                          ((session->mp->header.tlen - session->mp->len) /
-                          MAX_CRYPTO_DATA_SIZE) * sizeof(struct RTPHeader) );
+                          MAX_CRYPTO_DATA_SIZE) * sizeof(struct RTPHeader));
 
             /* Push the previous message for processing */
             if (session->mcb) {
-                session->mcb (session->cs, session->mp);
+                session->mcb(session->cs, session->mp);
             } else {
                 free(session->mp);
             }

--- a/toxav/rtp.h
+++ b/toxav/rtp.h
@@ -64,7 +64,7 @@ struct RTPHeader {
     /* Non-standard TOX-specific fields */
     uint16_t cpart;/* Data offset of the current part */
     uint16_t tlen; /* Total message lenght */
-} __attribute__ ((packed));
+} __attribute__((packed));
 
 /* Check alignment */
 typedef char __fail_if_misaligned_1 [ sizeof(struct RTPHeader) == 80 ? 1 : -1 ];
@@ -74,7 +74,7 @@ struct RTPMessage {
 
     struct RTPHeader header;
     uint8_t data[];
-} __attribute__ ((packed));
+} __attribute__((packed));
 
 /* Check alignment */
 typedef char __fail_if_misaligned_2 [ sizeof(struct RTPMessage) == 82 ? 1 : -1 ];
@@ -96,16 +96,16 @@ typedef struct {
 
     BWController *bwc;
     void *cs;
-    int (*mcb) (void *, struct RTPMessage *msg);
+    int (*mcb)(void *, struct RTPMessage *msg);
 } RTPSession;
 
 
-RTPSession *rtp_new (int payload_type, Messenger *m, uint32_t friendnumber,
-                     BWController *bwc, void *cs,
-                     int (*mcb) (void *, struct RTPMessage *));
-void rtp_kill (RTPSession *session);
-int rtp_allow_receiving (RTPSession *session);
-int rtp_stop_receiving (RTPSession *session);
-int rtp_send_data (RTPSession *session, const uint8_t *data, uint16_t length);
+RTPSession *rtp_new(int payload_type, Messenger *m, uint32_t friendnumber,
+                    BWController *bwc, void *cs,
+                    int (*mcb)(void *, struct RTPMessage *));
+void rtp_kill(RTPSession *session);
+int rtp_allow_receiving(RTPSession *session);
+int rtp_stop_receiving(RTPSession *session);
+int rtp_send_data(RTPSession *session, const uint8_t *data, uint16_t length);
 
 #endif /* RTP_H */

--- a/toxav/toxav.c
+++ b/toxav/toxav.c
@@ -89,7 +89,7 @@ struct ToxAV {
     uint32_t interval; /** Calculated interval */
 };
 
-void callback_bwc (BWController *bwc, uint32_t friend_number, float loss, void *user_data);
+void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *user_data);
 
 int callback_invite(void *toxav_inst, MSICall *call);
 int callback_start(void *toxav_inst, MSICall *call);
@@ -146,7 +146,7 @@ ToxAV *toxav_new(Tox *tox, TOXAV_ERR_NEW *error)
         goto END;
     }
 
-    av = calloc (sizeof(ToxAV), 1);
+    av = calloc(sizeof(ToxAV), 1);
 
     if (av == NULL) {
         LOGGER_WARNING(m->log, "Allocation failed!");
@@ -904,13 +904,13 @@ void callback_bwc(BWController *bwc, uint32_t friend_number, float loss, void *u
     }
 
     if (call->video_bit_rate) {
-        (*call->av->bcb.first) (call->av, friend_number, call->audio_bit_rate,
-                                call->video_bit_rate - (call->video_bit_rate * loss),
-                                call->av->bcb.second);
+        (*call->av->bcb.first)(call->av, friend_number, call->audio_bit_rate,
+                               call->video_bit_rate - (call->video_bit_rate * loss),
+                               call->av->bcb.second);
     } else if (call->audio_bit_rate) {
-        (*call->av->bcb.first) (call->av, friend_number,
-                                call->audio_bit_rate - (call->audio_bit_rate * loss),
-                                0, call->av->bcb.second);
+        (*call->av->bcb.first)(call->av, friend_number,
+                               call->audio_bit_rate - (call->audio_bit_rate * loss),
+                               0, call->av->bcb.second);
     }
 
     pthread_mutex_unlock(call->av->mutex);
@@ -1079,7 +1079,7 @@ ToxAVCall *call_new(ToxAV *av, uint32_t friend_number, TOXAV_ERR_CALL *error)
     call->friend_number = friend_number;
 
     if (av->calls == NULL) { /* Creating */
-        av->calls = calloc (sizeof(ToxAVCall *), friend_number + 1);
+        av->calls = calloc(sizeof(ToxAVCall *), friend_number + 1);
 
         if (av->calls == NULL) {
             free(call);

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -642,7 +642,7 @@ static void get_close_nodes_inner(const uint8_t *public_key, Node_format *nodes_
         if (num_nodes < MAX_SENT_NODES) {
             memcpy(nodes_list[num_nodes].public_key,
                    client->public_key,
-                   crypto_box_PUBLICKEYBYTES );
+                   crypto_box_PUBLICKEYBYTES);
 
             nodes_list[num_nodes].ip_port = ipptp->ip_port;
             num_nodes++;
@@ -827,11 +827,11 @@ static void sort_client_list(Client_data *list, unsigned int length, const uint8
  *  than public_key.
  *
  *  returns True(1) when the item was stored, False(0) otherwise */
-static int replace_all(   Client_data    *list,
-                          uint16_t        length,
-                          const uint8_t  *public_key,
-                          IP_Port         ip_port,
-                          const uint8_t  *comp_public_key )
+static int replace_all(Client_data    *list,
+                       uint16_t        length,
+                       const uint8_t  *public_key,
+                       IP_Port         ip_port,
+                       const uint8_t  *comp_public_key)
 {
     if ((ip_port.ip.family != AF_INET) && (ip_port.ip.family != AF_INET6)) {
         return 0;
@@ -1197,11 +1197,11 @@ static int getnodes(DHT *dht, IP_Port ip_port, const uint8_t *public_key, const 
     uint8_t nonce[crypto_box_NONCEBYTES];
     new_nonce(nonce);
 
-    int len = encrypt_data_symmetric( shared_key,
-                                      nonce,
-                                      plain,
-                                      sizeof(plain),
-                                      encrypt );
+    int len = encrypt_data_symmetric(shared_key,
+                                     nonce,
+                                     plain,
+                                     sizeof(plain),
+                                     encrypt);
 
     if (len != sizeof(encrypt)) {
         return -1;
@@ -1252,11 +1252,11 @@ static int sendnodes_ipv6(const DHT *dht, IP_Port ip_port, const uint8_t *public
 
     plain[0] = num_nodes;
     memcpy(plain + 1 + nodes_length, sendback_data, length);
-    int len = encrypt_data_symmetric( shared_encryption_key,
-                                      nonce,
-                                      plain,
-                                      1 + nodes_length + length,
-                                      encrypt );
+    int len = encrypt_data_symmetric(shared_encryption_key,
+                                     nonce,
+                                     plain,
+                                     1 + nodes_length + length,
+                                     encrypt);
 
     if (len != 1 + nodes_length + length + crypto_box_MACBYTES) {
         return -1;
@@ -1288,11 +1288,11 @@ static int handle_getnodes(void *object, IP_Port source, const uint8_t *packet, 
     uint8_t shared_key[crypto_box_BEFORENMBYTES];
 
     DHT_get_shared_key_recv(dht, shared_key, packet + 1);
-    int len = decrypt_data_symmetric( shared_key,
-                                      packet + 1 + crypto_box_PUBLICKEYBYTES,
-                                      packet + 1 + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES,
-                                      crypto_box_PUBLICKEYBYTES + sizeof(uint64_t) + crypto_box_MACBYTES,
-                                      plain );
+    int len = decrypt_data_symmetric(shared_key,
+                                     packet + 1 + crypto_box_PUBLICKEYBYTES,
+                                     packet + 1 + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES,
+                                     crypto_box_PUBLICKEYBYTES + sizeof(uint64_t) + crypto_box_MACBYTES,
+                                     plain);
 
     if (len != crypto_box_PUBLICKEYBYTES + sizeof(uint64_t)) {
         return 1;
@@ -1515,9 +1515,9 @@ int DHT_delfriend(DHT *dht, const uint8_t *public_key, uint16_t lock_count)
     --dht->num_friends;
 
     if (dht->num_friends != friend_num) {
-        memcpy( &dht->friends_list[friend_num],
-                &dht->friends_list[dht->num_friends],
-                sizeof(DHT_Friend) );
+        memcpy(&dht->friends_list[friend_num],
+               &dht->friends_list[dht->num_friends],
+               sizeof(DHT_Friend));
     }
 
     if (dht->num_friends == 0) {
@@ -1819,13 +1819,15 @@ static int friend_iplist(const DHT *dht, IP_Port *ip_portlist, uint16_t friend_n
 #ifdef FRIEND_IPLIST_PAD
     memcpy(ip_portlist, ipv6s, num_ipv6s * sizeof(IP_Port));
 
-    if (num_ipv6s == MAX_FRIEND_CLIENTS)
+    if (num_ipv6s == MAX_FRIEND_CLIENTS) {
         return MAX_FRIEND_CLIENTS;
+    }
 
     int num_ipv4s_used = MAX_FRIEND_CLIENTS - num_ipv6s;
 
-    if (num_ipv4s_used > num_ipv4s)
+    if (num_ipv4s_used > num_ipv4s) {
         num_ipv4s_used = num_ipv4s;
+    }
 
     memcpy(&ip_portlist[num_ipv6s], ipv4s, num_ipv4s_used * sizeof(IP_Port));
     return num_ipv6s + num_ipv4s_used;
@@ -2654,8 +2656,9 @@ void do_DHT(DHT *dht)
 #endif
 #ifdef ENABLE_ASSOC_DHT
 
-    if (dht->assoc)
+    if (dht->assoc) {
         do_Assoc(dht->assoc, dht);
+    }
 
 #endif
     dht->last_run = unix_time();

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -1892,7 +1892,7 @@ Messenger *new_messenger(Logger *log, Messenger_Options *options, unsigned int *
         *error = MESSENGER_ERROR_OTHER;
     }
 
-    if ( ! m ) {
+    if (! m) {
         return NULL;
     }
 

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -1184,8 +1184,9 @@ static void do_TCP_confirmed(TCP_Server *TCP_server)
 {
 #ifdef TCP_SERVER_USE_EPOLL
 
-    if (TCP_server->last_run_pinged == unix_time())
+    if (TCP_server->last_run_pinged == unix_time()) {
         return;
+    }
 
     TCP_server->last_run_pinged = unix_time();
 #endif

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -56,8 +56,9 @@ static const char *inet_ntop(sa_family_t family, void *addr, char *buf, size_t b
 
         DWORD len = bufsize;
 
-        if (WSAAddressToString((LPSOCKADDR)&saddr, sizeof(saddr), NULL, buf, &len))
+        if (WSAAddressToString((LPSOCKADDR)&saddr, sizeof(saddr), NULL, buf, &len)) {
             return NULL;
+        }
 
         return buf;
     } else if (family == AF_INET6) {
@@ -69,8 +70,9 @@ static const char *inet_ntop(sa_family_t family, void *addr, char *buf, size_t b
 
         DWORD len = bufsize;
 
-        if (WSAAddressToString((LPSOCKADDR)&saddr, sizeof(saddr), NULL, buf, &len))
+        if (WSAAddressToString((LPSOCKADDR)&saddr, sizeof(saddr), NULL, buf, &len)) {
             return NULL;
+        }
 
         return buf;
     }
@@ -86,8 +88,9 @@ static int inet_pton(sa_family_t family, const char *addrString, void *addrbuf)
 
         INT len = sizeof(saddr);
 
-        if (WSAStringToAddress((LPTSTR)addrString, AF_INET, NULL, (LPSOCKADDR)&saddr, &len))
+        if (WSAStringToAddress((LPTSTR)addrString, AF_INET, NULL, (LPSOCKADDR)&saddr, &len)) {
             return 0;
+        }
 
         *(struct in_addr *)addrbuf = saddr.sin_addr;
 
@@ -98,8 +101,9 @@ static int inet_pton(sa_family_t family, const char *addrString, void *addrbuf)
 
         INT len = sizeof(saddr);
 
-        if (WSAStringToAddress((LPTSTR)addrString, AF_INET6, NULL, (LPSOCKADDR)&saddr, &len))
+        if (WSAStringToAddress((LPTSTR)addrString, AF_INET6, NULL, (LPSOCKADDR)&saddr, &len)) {
             return 0;
+        }
 
         *(struct in6_addr *)addrbuf = saddr.sin6_addr;
 
@@ -480,8 +484,9 @@ int networking_at_startup(void)
 #if defined(_WIN32) || defined(__WIN32__) || defined (WIN32)
     WSADATA wsaData;
 
-    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != NO_ERROR)
+    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != NO_ERROR) {
         return -1;
+    }
 
 #endif
     srand((uint32_t)current_time_actual());
@@ -645,7 +650,7 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
     if (ip.family == AF_INET6) {
         int is_dualstack = set_socket_dualstack(temp->sock);
         LOGGER_DEBUG(log, "Dual-stack socket: %s",
-                     is_dualstack ? "enabled" : "Failed to enable, won't be able to receive from/send to IPv4 addresses" );
+                     is_dualstack ? "enabled" : "Failed to enable, won't be able to receive from/send to IPv4 addresses");
         /* multicast local nodes */
         struct ipv6_mreq mreq;
         memset(&mreq, 0, sizeof(mreq));
@@ -656,7 +661,7 @@ Networking_Core *new_networking_ex(Logger *log, IP ip, uint16_t port_from, uint1
         int res = setsockopt(temp->sock, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (char *)&mreq, sizeof(mreq));
 
         LOGGER_DEBUG(log, res < 0 ? "Failed to activate local multicast membership. (%u, %s)" :
-                     "Local multicast group FF02::1 joined successfully", errno, strerror(errno) );
+                     "Local multicast group FF02::1 joined successfully", errno, strerror(errno));
     }
 
     /* a hanging program or a different user might block the standard port;

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -642,7 +642,7 @@ static int client_ping_nodes(Onion_Client *onion_c, uint32_t num, const Node_for
         if (is_timeout(list_nodes[0].timestamp, ONION_NODE_TIMEOUT)
                 || id_closest(reference_id, list_nodes[0].public_key, nodes[i].public_key) == 2
                 || is_timeout(list_nodes[1].timestamp, ONION_NODE_TIMEOUT)
-                || id_closest(reference_id, list_nodes[1].public_key, nodes[i].public_key) == 2 ) {
+                || id_closest(reference_id, list_nodes[1].public_key, nodes[i].public_key) == 2) {
             /* check if node is already in list. */
             for (j = 0; j < list_length; ++j) {
                 if (public_key_cmp(list_nodes[j].public_key, nodes[i].public_key) == 0) {

--- a/toxcore/ping.c
+++ b/toxcore/ping.c
@@ -125,7 +125,7 @@ static int send_ping_response(PING *ping, IP_Port ipp, const uint8_t *public_key
     rc = encrypt_data_symmetric(shared_encryption_key,
                                 pk + 1 + crypto_box_PUBLICKEYBYTES,
                                 ping_plain, sizeof(ping_plain),
-                                pk + 1 + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES );
+                                pk + 1 + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES);
 
     if (rc != PING_PLAIN_SIZE + crypto_box_MACBYTES) {
         return 1;
@@ -158,7 +158,7 @@ static int handle_ping_request(void *_dht, IP_Port source, const uint8_t *packet
                                 packet + 1 + crypto_box_PUBLICKEYBYTES,
                                 packet + 1 + crypto_box_PUBLICKEYBYTES + crypto_box_NONCEBYTES,
                                 PING_PLAIN_SIZE + crypto_box_MACBYTES,
-                                ping_plain );
+                                ping_plain);
 
     if (rc != sizeof(ping_plain)) {
         return 1;

--- a/toxcore/util.c
+++ b/toxcore/util.c
@@ -86,7 +86,7 @@ void host_to_net(uint8_t *num, uint16_t numbytes)
 uint16_t lendian_to_host16(uint16_t lendian)
 {
 #ifdef WORDS_BIGENDIAN
-    return  (lendian << 8) | (lendian >> 8 );
+    return (lendian << 8) | (lendian >> 8);
 #else
     return lendian;
 #endif
@@ -95,7 +95,7 @@ uint16_t lendian_to_host16(uint16_t lendian)
 void host_to_lendian32(uint8_t *dest,  uint32_t num)
 {
 #ifdef WORDS_BIGENDIAN
-    num = ((num << 8) & 0xFF00FF00 ) | ((num >> 8) & 0xFF00FF );
+    num = ((num << 8) & 0xFF00FF00) | ((num >> 8) & 0xFF00FF);
     num = (num << 16) | (num >> 16);
 #endif
     memcpy(dest, &num, sizeof(uint32_t));
@@ -106,7 +106,7 @@ void lendian_to_host32(uint32_t *dest, const uint8_t *lendian)
     uint32_t d;
     memcpy(&d, lendian, sizeof(uint32_t));
 #ifdef WORDS_BIGENDIAN
-    d = ((d << 8) & 0xFF00FF00 ) | ((d >> 8) & 0xFF00FF );
+    d = ((d << 8) & 0xFF00FF00) | ((d >> 8) & 0xFF00FF);
     d = (d << 16) | (d >> 16);
 #endif
     *dest = d;


### PR DESCRIPTION
It now enforces a bit more formatting. In particular, padding inside
parentheses is removed. I would like it to remove padding after unary
operators, but there seems to be no option for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/134)
<!-- Reviewable:end -->
