### PR TITLE
Use <stdbool.h> and replace _Bool with bool.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -522,7 +522,7 @@ END_TEST
 
 #include "../toxcore/TCP_connection.h"
 
-_Bool tcp_data_callback_called;
+bool tcp_data_callback_called;
 static int tcp_data_callback(void *object, int id, const uint8_t *data, uint16_t length, void *userdata)
 {
     if (object != (void *)120397) {
@@ -631,7 +631,7 @@ START_TEST(test_tcp_connection)
 }
 END_TEST
 
-_Bool tcp_oobdata_callback_called;
+bool tcp_oobdata_callback_called;
 static int tcp_oobdata_callback(void *object, const uint8_t *public_key, unsigned int id, const uint8_t *data,
                                 uint16_t length, void *userdata)
 {

--- a/auto_tests/onion_test.c
+++ b/auto_tests/onion_test.c
@@ -323,7 +323,7 @@ static void kill_onions(Onions *on)
 #define NUM_FIRST 7
 #define NUM_LAST 37
 
-static _Bool first_ip, last_ip;
+static bool first_ip, last_ip;
 static void dht_ip_callback(void *object, int32_t number, IP_Port ip_port)
 {
     if (NUM_FIRST == number) {
@@ -339,7 +339,7 @@ static void dht_ip_callback(void *object, int32_t number, IP_Port ip_port)
     ck_abort_msg("Error.");
 }
 
-static _Bool first, last;
+static bool first, last;
 static uint8_t first_dht_pk[crypto_box_PUBLICKEYBYTES];
 static uint8_t last_dht_pk[crypto_box_PUBLICKEYBYTES];
 

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -224,9 +224,9 @@ static void file_print_control(Tox *tox, uint32_t friend_number, uint32_t file_n
 }
 
 static uint64_t max_sending;
-static _Bool m_send_reached;
+static bool m_send_reached;
 static uint8_t sending_num;
-static _Bool file_sending_done;
+static bool file_sending_done;
 static void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position,
                                    size_t length,
                                    void *user_data)
@@ -280,7 +280,7 @@ static void tox_file_chunk_request(Tox *tox, uint32_t friend_number, uint32_t fi
 
 
 static uint8_t num;
-static _Bool file_recv;
+static bool file_recv;
 static void write_file(Tox *tox, uint32_t friendnumber, uint32_t filenumber, uint64_t position, const uint8_t *data,
                        size_t length, void *user_data)
 {

--- a/toxcore/DHT.c
+++ b/toxcore/DHT.c
@@ -550,8 +550,8 @@ static int friend_number(const DHT *dht, const uint8_t *public_key)
 
 /* Add node to the node list making sure only the nodes closest to cmp_pk are in the list.
  */
-_Bool add_to_list(Node_format *nodes_list, unsigned int length, const uint8_t *pk, IP_Port ip_port,
-                  const uint8_t *cmp_pk)
+bool add_to_list(Node_format *nodes_list, unsigned int length, const uint8_t *pk, IP_Port ip_port,
+                 const uint8_t *cmp_pk)
 {
     uint8_t pk_bak[crypto_box_PUBLICKEYBYTES];
     IP_Port ip_port_bak;
@@ -877,7 +877,7 @@ static int replace_all(Client_data    *list,
  * return -1 on failure.
  * return 0 on success.
  */
-static int add_to_close(DHT *dht, const uint8_t *public_key, IP_Port ip_port, _Bool simulate)
+static int add_to_close(DHT *dht, const uint8_t *public_key, IP_Port ip_port, bool simulate)
 {
     unsigned int i;
 
@@ -924,7 +924,7 @@ static int add_to_close(DHT *dht, const uint8_t *public_key, IP_Port ip_port, _B
 
 /* Return 1 if node can be added to close list, 0 if it can't.
  */
-_Bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_port)
+bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_port)
 {
     if (add_to_close(dht, public_key, ip_port, 1) == 0) {
         return 1;
@@ -933,8 +933,8 @@ _Bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip
     return 0;
 }
 
-static _Bool is_pk_in_client_list(Client_data *list, unsigned int client_list_length, const uint8_t *public_key,
-                                  IP_Port ip_port)
+static bool is_pk_in_client_list(Client_data *list, unsigned int client_list_length, const uint8_t *public_key,
+                                 IP_Port ip_port)
 {
     unsigned int i;
 
@@ -958,7 +958,7 @@ static _Bool is_pk_in_client_list(Client_data *list, unsigned int client_list_le
  */
 static unsigned int ping_node_from_getnodes_ok(DHT *dht, const uint8_t *public_key, IP_Port ip_port)
 {
-    _Bool ret = 0;
+    bool ret = 0;
 
     if (add_to_close(dht, public_key, ip_port, 1) == 0) {
         ret = 1;
@@ -978,7 +978,7 @@ static unsigned int ping_node_from_getnodes_ok(DHT *dht, const uint8_t *public_k
     unsigned int i;
 
     for (i = 0; i < dht->num_friends; ++i) {
-        _Bool store_ok = 0;
+        bool store_ok = 0;
 
         DHT_Friend *friend = &dht->friends_list[i];
 
@@ -1572,7 +1572,7 @@ int DHT_getfriendip(const DHT *dht, const uint8_t *public_key, IP_Port *ip_port)
 
 /* returns number of nodes not in kill-timeout */
 static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, const uint8_t *public_key,
-        Client_data *list, uint32_t list_count, uint32_t *bootstrap_times, _Bool sortable)
+        Client_data *list, uint32_t list_count, uint32_t *bootstrap_times, bool sortable)
 {
     uint32_t i;
     uint8_t not_kill = 0;
@@ -1582,7 +1582,7 @@ static uint8_t do_ping_and_sendnode_requests(DHT *dht, uint64_t *lastgetnode, co
     Client_data *client_list[list_count * 2];
     IPPTsPng    *assoc_list[list_count * 2];
     unsigned int sort = 0;
-    _Bool sort_ok = 0;
+    bool sort_ok = 0;
 
     for (i = 0; i < list_count; i++) {
         /* If node is not dead. */

--- a/toxcore/DHT.h
+++ b/toxcore/DHT.h
@@ -29,6 +29,8 @@
 #include "network.h"
 #include "ping_array.h"
 
+#include <stdbool.h>
+
 /* Maximum number of clients stored per friend. */
 #define MAX_FRIEND_CLIENTS 8
 
@@ -311,12 +313,12 @@ int id_closest(const uint8_t *pk, const uint8_t *pk1, const uint8_t *pk2);
 
 /* Add node to the node list making sure only the nodes closest to cmp_pk are in the list.
  */
-_Bool add_to_list(Node_format *nodes_list, unsigned int length, const uint8_t *pk, IP_Port ip_port,
-                  const uint8_t *cmp_pk);
+bool add_to_list(Node_format *nodes_list, unsigned int length, const uint8_t *pk, IP_Port ip_port,
+                 const uint8_t *cmp_pk);
 
 /* Return 1 if node can be added to close list, 0 if it can't.
  */
-_Bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_port);
+bool node_addable_to_close_list(DHT *dht, const uint8_t *public_key, IP_Port ip_port);
 
 /* Get the (maximum MAX_SENT_NODES) closest nodes to public_key we know
  * and put them in nodes_list (must be MAX_SENT_NODES big).

--- a/toxcore/LAN_discovery.c
+++ b/toxcore/LAN_discovery.c
@@ -235,7 +235,7 @@ static IP broadcast_ip(sa_family_t family_socket, sa_family_t family_broadcast)
 }
 
 /* Is IP a local ip or not. */
-_Bool Local_ip(IP ip)
+bool Local_ip(IP ip)
 {
     if (ip.family == AF_INET) {
         IP4 ip4 = ip.ip4;

--- a/toxcore/LAN_discovery.h
+++ b/toxcore/LAN_discovery.h
@@ -40,7 +40,7 @@ void LANdiscovery_init(DHT *dht);
 void LANdiscovery_kill(DHT *dht);
 
 /* Is IP a local ip or not. */
-_Bool Local_ip(IP ip);
+bool Local_ip(IP ip);
 
 /* checks if a given IP isn't routable
  *

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -450,7 +450,7 @@ int m_get_friend_connectionstatus(const Messenger *m, int32_t friendnumber)
     }
 
     if (m->friendlist[friendnumber].status == FRIEND_ONLINE) {
-        _Bool direct_connected = 0;
+        bool direct_connected = 0;
         unsigned int num_online_relays = 0;
         int crypt_conn_id = friend_connection_crypt_connection_id(m->fr_c, m->friendlist[friendnumber].friendcon_id);
         crypto_connection_status(m->net_crypto, crypt_conn_id, &direct_connected, &num_online_relays);
@@ -865,7 +865,7 @@ void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, uint32_t
     m->friend_userstatuschange = function;
 }
 
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, _Bool, void *))
+void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, bool, void *))
 {
     m->friend_typingchange = function;
 }
@@ -2141,7 +2141,7 @@ static int handle_packet(void *object, int i, const uint8_t *temp, uint16_t len,
                 break;
             }
 
-            _Bool typing = !!data[0];
+            bool typing = !!data[0];
 
             set_friend_typing(m, i, typing);
 

--- a/toxcore/Messenger.h
+++ b/toxcore/Messenger.h
@@ -242,7 +242,7 @@ struct Messenger {
     void (*friend_namechange)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
     void (*friend_statusmessagechange)(struct Messenger *m, uint32_t, const uint8_t *, size_t, void *);
     void (*friend_userstatuschange)(struct Messenger *m, uint32_t, unsigned int, void *);
-    void (*friend_typingchange)(struct Messenger *m, uint32_t, _Bool, void *);
+    void (*friend_typingchange)(struct Messenger *m, uint32_t, bool, void *);
     void (*read_receipt)(struct Messenger *m, uint32_t, uint32_t, void *);
     void (*friend_connectionstatuschange)(struct Messenger *m, uint32_t, unsigned int, void *);
     void (*friend_connectionstatuschange_internal)(struct Messenger *m, uint32_t, uint8_t, void *);
@@ -494,7 +494,7 @@ void m_callback_userstatus(Messenger *m, void (*function)(Messenger *m, uint32_t
 /* Set the callback for typing changes.
  *  Function(uint32_t friendnumber, uint8_t is_typing)
  */
-void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, _Bool, void *));
+void m_callback_typingchange(Messenger *m, void(*function)(Messenger *m, uint32_t, bool, void *));
 
 /* Set the callback for read receipts.
  *  Function(uint32_t friendnumber, uint32_t receipt)

--- a/toxcore/TCP_client.c
+++ b/toxcore/TCP_client.c
@@ -330,7 +330,7 @@ static int send_pending_data(TCP_Client_Connection *con)
 /* return 0 on failure (only if malloc fails)
  * return 1 on success
  */
-static _Bool add_priority(TCP_Client_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
+static bool add_priority(TCP_Client_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end, *new;
     new = malloc(sizeof(TCP_Priority_List) + size);
@@ -370,13 +370,13 @@ static void wipe_priority_list(TCP_Client_Connection *con)
  * return -1 on failure (connection must be killed).
  */
 static int write_packet_TCP_secure_connection(TCP_Client_Connection *con, const uint8_t *data, uint16_t length,
-        _Bool priority)
+        bool priority)
 {
     if (length + crypto_box_MACBYTES > MAX_PACKET_SIZE) {
         return -1;
     }
 
-    _Bool sendpriority = 1;
+    bool sendpriority = 1;
 
     if (send_pending_data(con) == -1) {
         if (priority) {

--- a/toxcore/TCP_connection.c
+++ b/toxcore/TCP_connection.c
@@ -40,7 +40,7 @@
 /* return 1 if the connections_number is not valid.
  * return 0 if the connections_number is valid.
  */
-static _Bool connections_number_not_valid(const TCP_Connections *tcp_c, int connections_number)
+static bool connections_number_not_valid(const TCP_Connections *tcp_c, int connections_number)
 {
     if ((unsigned int)connections_number >= tcp_c->connections_length) {
         return 1;
@@ -60,7 +60,7 @@ static _Bool connections_number_not_valid(const TCP_Connections *tcp_c, int conn
 /* return 1 if the tcp_connections_number is not valid.
  * return 0 if the tcp_connections_number is valid.
  */
-static _Bool tcp_connections_number_not_valid(const TCP_Connections *tcp_c, int tcp_connections_number)
+static bool tcp_connections_number_not_valid(const TCP_Connections *tcp_c, int tcp_connections_number)
 {
     if ((unsigned int)tcp_connections_number >= tcp_c->tcp_connections_length) {
         return 1;
@@ -228,7 +228,7 @@ int send_packet_tcp_connection(TCP_Connections *tcp_c, int connections_number, c
     unsigned int i;
     int ret = -1;
 
-    _Bool limit_reached = 0;
+    bool limit_reached = 0;
 
     for (i = 0; i < MAX_FRIEND_TCP_CONNECTIONS; ++i) {
         uint32_t tcp_con_num = con_to->connections[i].tcp_connection;
@@ -522,7 +522,7 @@ int kill_tcp_connection_to(TCP_Connections *tcp_c, int connections_number)
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, _Bool status)
+int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, bool status)
 {
     TCP_Connection_to *con_to = get_connection(tcp_c, connections_number);
 
@@ -583,7 +583,7 @@ int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number,
     return 0;
 }
 
-static _Bool tcp_connection_in_conn(TCP_Connection_to *con_to, unsigned int tcp_connections_number)
+static bool tcp_connection_in_conn(TCP_Connection_to *con_to, unsigned int tcp_connections_number)
 {
     unsigned int i;
 
@@ -1253,7 +1253,7 @@ unsigned int tcp_copy_connected_relays(TCP_Connections *tcp_c, Node_format *tcp_
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_onion_status(TCP_Connections *tcp_c, _Bool status)
+int set_tcp_onion_status(TCP_Connections *tcp_c, bool status)
 {
     if (tcp_c->onion_status == status) {
         return -1;

--- a/toxcore/TCP_connection.h
+++ b/toxcore/TCP_connection.h
@@ -70,12 +70,12 @@ typedef struct {
     uint64_t connected_time;
     uint32_t lock_count;
     uint32_t sleep_count;
-    _Bool onion;
+    bool onion;
 
     /* Only used when connection is sleeping. */
     IP_Port ip_port;
     uint8_t relay_pk[crypto_box_PUBLICKEYBYTES];
-    _Bool unsleep; /* set to 1 to unsleep connection. */
+    bool unsleep; /* set to 1 to unsleep connection. */
 } TCP_con;
 
 typedef struct {
@@ -102,7 +102,7 @@ typedef struct {
 
     TCP_Proxy_Info proxy_info;
 
-    _Bool onion_status;
+    bool onion_status;
     uint16_t onion_num_conns;
 } TCP_Connections;
 
@@ -138,7 +138,7 @@ int tcp_send_onion_request(TCP_Connections *tcp_c, unsigned int tcp_connections_
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_onion_status(TCP_Connections *tcp_c, _Bool status);
+int set_tcp_onion_status(TCP_Connections *tcp_c, bool status);
 
 /* Send an oob packet via the TCP relay corresponding to tcp_connections_number.
  *
@@ -190,7 +190,7 @@ int kill_tcp_connection_to(TCP_Connections *tcp_c, int connections_number);
  * return 0 on success.
  * return -1 on failure.
  */
-int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, _Bool status);
+int set_tcp_connection_to_status(TCP_Connections *tcp_c, int connections_number, bool status);
 
 /* return number of online tcp relays tied to the connection on success.
  * return 0 on failure.

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -369,7 +369,7 @@ static int send_pending_data(TCP_Secure_Connection *con)
 /* return 0 on failure (only if malloc fails)
  * return 1 on success
  */
-static _Bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
+static bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uint16_t size, uint16_t sent)
 {
     TCP_Priority_List *p = con->priority_queue_end, *new;
     new = malloc(sizeof(TCP_Priority_List) + size);
@@ -398,13 +398,13 @@ static _Bool add_priority(TCP_Secure_Connection *con, const uint8_t *packet, uin
  * return -1 on failure (connection must be killed).
  */
 static int write_packet_TCP_secure_connection(TCP_Secure_Connection *con, const uint8_t *data, uint16_t length,
-        _Bool priority)
+        bool priority)
 {
     if (length + crypto_box_MACBYTES > MAX_PACKET_SIZE) {
         return -1;
     }
 
-    _Bool sendpriority = 1;
+    bool sendpriority = 1;
 
     if (send_pending_data(con) == -1) {
         if (priority) {

--- a/toxcore/friend_connection.c
+++ b/toxcore/friend_connection.c
@@ -332,7 +332,7 @@ static int handle_status(void *object, int number, uint8_t status, void *userdat
         return -1;
     }
 
-    _Bool call_cb = 0;
+    bool call_cb = 0;
 
     if (status) {  /* Went online. */
         call_cb = 1;

--- a/toxcore/friend_connection.h
+++ b/toxcore/friend_connection.h
@@ -96,7 +96,7 @@ typedef struct {
     Node_format tcp_relays[FRIEND_MAX_STORED_TCP_RELAYS];
     uint16_t tcp_relay_counter;
 
-    _Bool hosting_tcp_relay;
+    bool hosting_tcp_relay;
 } Friend_Conn;
 
 

--- a/toxcore/net_crypto.c
+++ b/toxcore/net_crypto.c
@@ -473,7 +473,7 @@ static IP_Port return_ip_port_connection(Net_Crypto *c, int crypt_connection_id)
     }
 
     uint64_t current_time = unix_time();
-    _Bool v6 = 0, v4 = 0;
+    bool v6 = 0, v4 = 0;
 
     if ((UDP_DIRECT_TIMEOUT + conn->direct_lastrecv_timev4) > current_time) {
         v4 = 1;
@@ -519,7 +519,7 @@ static int send_packet_to(Net_Crypto *c, int crypt_connection_id, const uint8_t 
 
     //TODO: on bad networks, direct connections might not last indefinitely.
     if (ip_port.ip.family != 0) {
-        _Bool direct_connected = 0;
+        bool direct_connected = 0;
         crypto_connection_status(c, crypt_connection_id, &direct_connected, NULL);
 
         if (direct_connected) {
@@ -1322,7 +1322,7 @@ static void connection_kill(Net_Crypto *c, int crypt_connection_id, void *userda
  * return 0 on success.
  */
 static int handle_data_packet_helper(Net_Crypto *c, int crypt_connection_id, const uint8_t *packet, uint16_t length,
-                                     _Bool udp, void *userdata)
+                                     bool udp, void *userdata)
 {
     if (length > MAX_CRYPTO_PACKET_SIZE || length <= CRYPTO_DATA_PACKET_MIN_SIZE) {
         return -1;
@@ -1469,7 +1469,7 @@ static int handle_data_packet_helper(Net_Crypto *c, int crypt_connection_id, con
  * return 0 on success.
  */
 static int handle_packet_connection(Net_Crypto *c, int crypt_connection_id, const uint8_t *packet, uint16_t length,
-                                    _Bool udp, void *userdata)
+                                    bool udp, void *userdata)
 {
     if (length == 0 || length > MAX_CRYPTO_PACKET_SIZE) {
         return -1;
@@ -1911,7 +1911,7 @@ int new_crypto_connection(Net_Crypto *c, const uint8_t *real_public_key, const u
  * return -1 on failure.
  * return 0 on success.
  */
-int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, _Bool connected)
+int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, bool connected)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);
 
@@ -2098,7 +2098,7 @@ static void do_tcp(Net_Crypto *c, void *userdata)
         }
 
         if (conn->status == CRYPTO_CONN_ESTABLISHED) {
-            _Bool direct_connected = 0;
+            bool direct_connected = 0;
             crypto_connection_status(c, i, &direct_connected, NULL);
 
             if (direct_connected) {
@@ -2380,7 +2380,7 @@ static void send_crypto_packets(Net_Crypto *c)
                 conn->last_num_packets_sent[n_p_pos] = packets_sent;
                 conn->last_num_packets_resent[n_p_pos] = packets_resent;
 
-                _Bool direct_connected = 0;
+                bool direct_connected = 0;
                 crypto_connection_status(c, i, &direct_connected, NULL);
 
                 if (direct_connected && conn->last_tcp_sent + CONGESTION_EVENT_TIMEOUT > temp_time) {
@@ -2530,7 +2530,7 @@ static void send_crypto_packets(Net_Crypto *c)
 /* Return 1 if max speed was reached for this connection (no more data can be physically through the pipe).
  * Return 0 if it wasn't reached.
  */
-_Bool max_speed_reached(Net_Crypto *c, int crypt_connection_id)
+bool max_speed_reached(Net_Crypto *c, int crypt_connection_id)
 {
     return reset_max_speed_reached(c, crypt_connection_id) != 0;
 }
@@ -2721,7 +2721,7 @@ int crypto_kill(Net_Crypto *c, int crypt_connection_id)
  * sets direct_connected to 1 if connection connects directly to other, 0 if it isn't.
  * sets online_tcp_relays to the number of connected tcp relays this connection has.
  */
-unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, _Bool *direct_connected,
+unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, bool *direct_connected,
                                       unsigned int *online_tcp_relays)
 {
     Crypto_Connection *conn = get_crypto_connection(c, crypt_connection_id);

--- a/toxcore/net_crypto.h
+++ b/toxcore/net_crypto.h
@@ -252,7 +252,7 @@ int new_crypto_connection(Net_Crypto *c, const uint8_t *real_public_key, const u
  * return -1 on failure.
  * return 0 on success.
  */
-int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, _Bool connected);
+int set_direct_ip_port(Net_Crypto *c, int crypt_connection_id, IP_Port ip_port, bool connected);
 
 /* Set function to be called when connection with crypt_connection_id goes connects/disconnects.
  *
@@ -313,7 +313,7 @@ uint32_t crypto_num_free_sendqueue_slots(const Net_Crypto *c, int crypt_connecti
 /* Return 1 if max speed was reached for this connection (no more data can be physically through the pipe).
  * Return 0 if it wasn't reached.
  */
-_Bool max_speed_reached(Net_Crypto *c, int crypt_connection_id);
+bool max_speed_reached(Net_Crypto *c, int crypt_connection_id);
 
 /* Sends a lossless cryptopacket.
  *
@@ -391,7 +391,7 @@ int crypto_kill(Net_Crypto *c, int crypt_connection_id);
  * sets direct_connected to 1 if connection connects directly to other, 0 if it isn't.
  * sets online_tcp_relays to the number of connected tcp relays this connection has.
  */
-unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, _Bool *direct_connected,
+unsigned int crypto_connection_status(const Net_Crypto *c, int crypt_connection_id, bool *direct_connected,
                                       unsigned int *online_tcp_relays);
 
 /* Generate our public and private keys.

--- a/toxcore/onion.c
+++ b/toxcore/onion.c
@@ -62,7 +62,7 @@ static void ip_pack(uint8_t *data, IP source)
 }
 
 /* return 0 on success, -1 on failure. */
-static int ip_unpack(IP *target, const uint8_t *data, unsigned int data_size, _Bool disable_family_check)
+static int ip_unpack(IP *target, const uint8_t *data, unsigned int data_size, bool disable_family_check)
 {
     if (data_size < (1 + SIZE_IP6)) {
         return -1;
@@ -91,7 +91,7 @@ static void ipport_pack(uint8_t *data, const IP_Port *source)
 }
 
 /* return 0 on success, -1 on failure. */
-static int ipport_unpack(IP_Port *target, const uint8_t *data, unsigned int data_size, _Bool disable_family_check)
+static int ipport_unpack(IP_Port *target, const uint8_t *data, unsigned int data_size, bool disable_family_check)
 {
     if (data_size < (SIZE_IP + SIZE_PORT)) {
         return -1;

--- a/toxcore/onion_client.c
+++ b/toxcore/onion_client.c
@@ -213,7 +213,7 @@ static int is_path_used(const Onion_Client_Paths *onion_paths, const Node_format
 }
 
 /* is path timed out */
-static _Bool path_timed_out(Onion_Client_Paths *onion_paths, uint32_t pathnum)
+static bool path_timed_out(Onion_Client_Paths *onion_paths, uint32_t pathnum)
 {
     pathnum = pathnum % NUMBER_ONION_PATHS;
 
@@ -275,7 +275,7 @@ static int random_path(const Onion_Client *onion_c, Onion_Client_Paths *onion_pa
 }
 
 /* Does path with path_num exist. */
-static _Bool path_exists(Onion_Client_Paths *onion_paths, uint32_t path_num)
+static bool path_exists(Onion_Client_Paths *onion_paths, uint32_t path_num)
 {
     if (path_timed_out(onion_paths, path_num)) {
         return 0;
@@ -1577,7 +1577,7 @@ void do_onion_client(Onion_Client *onion_c)
         }
     }
 
-    _Bool UDP_connected = DHT_non_lan_connected(onion_c->dht);
+    bool UDP_connected = DHT_non_lan_connected(onion_c->dht);
 
     if (is_timeout(onion_c->first_run, ONION_CONNECTION_SECONDS * 2)) {
         set_tcp_onion_status(onion_c->c->tcp_c, !UDP_connected);

--- a/toxcore/onion_client.h
+++ b/toxcore/onion_client.h
@@ -160,7 +160,7 @@ typedef struct {
     uint64_t last_packet_recv;
 
     unsigned int onion_connected;
-    _Bool UDP_connected;
+    bool UDP_connected;
 } Onion_Client;
 
 

--- a/toxcore/tox.c
+++ b/toxcore/tox.c
@@ -179,7 +179,7 @@ Tox *tox_new(const struct Tox_Options *options, TOX_ERR_NEW *error)
 {
     Messenger_Options m_options = {0};
 
-    _Bool load_savedata_sk = 0, load_savedata_tox = 0;
+    bool load_savedata_sk = 0, load_savedata_tox = 0;
 
     if (options == NULL) {
         m_options.ipv6enabled = TOX_ENABLE_IPV6_DEFAULT;


### PR DESCRIPTION
This header is a requirement for the public API, therefore is assumed to
exist. It is a C99 standard library header, and _Bool is not intended to
be used directly, except in legacy code that defines bool (and
true/false) itself. We don't use or depend on such code. None of our
client code uses or depends on such code. There is no reason to not use
bool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/137)
<!-- Reviewable:end -->
