### PR TITLE
Remove format-source from travis script.

### DIFF
--- a/other/travis/toxcore-script
+++ b/other/travis/toxcore-script
@@ -3,10 +3,6 @@
 set -e -u -x
 . other/travis/env-$ENV.sh
 
-# Check if the code is formatted according to the astyle configuration.
-other/astyle/format-source
-git diff --exit-code
-
 # Build toxcore and run tests.
 export CFLAGS="-O3 -fprofile-arcs -ftest-coverage -DTRAVIS_ENV=1"
 # TODO(iphydf): Enable ASAN. It currently has some bad interactions with gcov,


### PR DESCRIPTION
This test is already performed by `make test` later on. We originally
had it in the Travis script to make it fail fast when the format is
wrong, but there is also some value in running all tests despite format
errors.

Fixes #83. There are no more relevant phases that would benefit from the
padding lines proposed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/138)
<!-- Reviewable:end -->
