### PR TITLE
Use C99 %zu format conversion in printf for size_t.

### DIFF
--- a/testing/Messenger_test.c
+++ b/testing/Messenger_test.c
@@ -59,7 +59,7 @@
 static void print_message(Messenger *m, uint32_t friendnumber, unsigned int type, const uint8_t *string, size_t length,
                           void *userdata)
 {
-    printf("Message with length %lu received from %u: %s \n", length, friendnumber, string);
+    printf("Message with length %zu received from %u: %s \n", length, friendnumber, string);
     m_send_message_generic(m, friendnumber, type, (const uint8_t *)"Test1", 6, 0);
 }
 
@@ -81,7 +81,7 @@ static void print_request(Messenger *m, const uint8_t *public_key, const uint8_t
         printf("%hhX", public_key[j]);
     }
 
-    printf("\nOf length: %lu with data: %s \n", length, data);
+    printf("\nOf length: %zu with data: %s \n", length, data);
 
     if (length != sizeof("Install Gentoo")) {
         return;


### PR DESCRIPTION
size_t is unsigned long long on LLP64 and %lu prints unsigned long (32
bit), potentially causing problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/140)
<!-- Reviewable:end -->
