### PR TITLE
Make internal chat list function take uint32_t* as well.

### DIFF
--- a/toxcore/group.c
+++ b/toxcore/group.c
@@ -2510,7 +2510,7 @@ uint32_t count_chatlist(Group_Chats *g_c)
  * Otherwise, returns the number of elements copied.
  * If the array was too small, the contents
  * of out_list will be truncated to list_size. */
-uint32_t copy_chatlist(Group_Chats *g_c, int32_t *out_list, uint32_t list_size)
+uint32_t copy_chatlist(Group_Chats *g_c, uint32_t *out_list, uint32_t list_size)
 {
     if (!out_list) {
         return 0;

--- a/toxcore/group.h
+++ b/toxcore/group.h
@@ -321,7 +321,7 @@ uint32_t count_chatlist(Group_Chats *g_c);
  * Otherwise, returns the number of elements copied.
  * If the array was too small, the contents
  * of out_list will be truncated to list_size. */
-uint32_t copy_chatlist(Group_Chats *g_c, int32_t *out_list, uint32_t list_size);
+uint32_t copy_chatlist(Group_Chats *g_c, uint32_t *out_list, uint32_t list_size);
 
 /* return the type of groupchat (GROUPCHAT_TYPE_) that groupnumber is.
  *


### PR DESCRIPTION
The public one already does this, and the internal one actually assigns
`uint32_t`s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toxcore/145)
<!-- Reviewable:end -->
