### PR TITLE
Make TCP_Server opaque.

### DIFF
--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2477,7 +2477,8 @@ void do_messenger(Messenger *m, void *userdata)
             local_ip_port.port = m->options.tcp_server_port;
             local_ip_port.ip.family = AF_INET;
             local_ip_port.ip.ip4.uint32 = INADDR_LOOPBACK;
-            add_tcp_relay(m->net_crypto, local_ip_port, m->tcp_server->public_key);
+            add_tcp_relay(m->net_crypto, local_ip_port,
+                          tcp_server_public_key(m->tcp_server));
         }
     }
 

--- a/toxcore/TCP_server.c
+++ b/toxcore/TCP_server.c
@@ -32,6 +32,42 @@
 #include <sys/ioctl.h>
 #endif
 
+struct TCP_Server {
+    Onion *onion;
+
+#ifdef TCP_SERVER_USE_EPOLL
+    int efd;
+    uint64_t last_run_pinged;
+#endif
+    sock_t *socks_listening;
+    unsigned int num_listening_socks;
+
+    uint8_t public_key[crypto_box_PUBLICKEYBYTES];
+    uint8_t secret_key[crypto_box_SECRETKEYBYTES];
+    TCP_Secure_Connection incomming_connection_queue[MAX_INCOMMING_CONNECTIONS];
+    uint16_t incomming_connection_queue_index;
+    TCP_Secure_Connection unconfirmed_connection_queue[MAX_INCOMMING_CONNECTIONS];
+    uint16_t unconfirmed_connection_queue_index;
+
+    TCP_Secure_Connection *accepted_connection_array;
+    uint32_t size_accepted_connections;
+    uint32_t num_accepted_connections;
+
+    uint64_t counter;
+
+    BS_LIST accepted_key_list;
+};
+
+const uint8_t *tcp_server_public_key(const TCP_Server *tcp_server)
+{
+    return tcp_server->public_key;
+}
+
+size_t tcp_server_listen_count(const TCP_Server *tcp_server)
+{
+    return tcp_server->num_listening_socks;
+}
+
 /* return 1 on success
  * return 0 on failure
  */

--- a/toxcore/TCP_server.h
+++ b/toxcore/TCP_server.h
@@ -115,31 +115,10 @@ typedef struct TCP_Secure_Connection {
 } TCP_Secure_Connection;
 
 
-typedef struct {
-    Onion *onion;
+typedef struct TCP_Server TCP_Server;
 
-#ifdef TCP_SERVER_USE_EPOLL
-    int efd;
-    uint64_t last_run_pinged;
-#endif
-    sock_t *socks_listening;
-    unsigned int num_listening_socks;
-
-    uint8_t public_key[crypto_box_PUBLICKEYBYTES];
-    uint8_t secret_key[crypto_box_SECRETKEYBYTES];
-    TCP_Secure_Connection incomming_connection_queue[MAX_INCOMMING_CONNECTIONS];
-    uint16_t incomming_connection_queue_index;
-    TCP_Secure_Connection unconfirmed_connection_queue[MAX_INCOMMING_CONNECTIONS];
-    uint16_t unconfirmed_connection_queue_index;
-
-    TCP_Secure_Connection *accepted_connection_array;
-    uint32_t size_accepted_connections;
-    uint32_t num_accepted_connections;
-
-    uint64_t counter;
-
-    BS_LIST accepted_key_list;
-} TCP_Server;
+const uint8_t *tcp_server_public_key(const TCP_Server *tcp_server);
+size_t tcp_server_listen_count(const TCP_Server *tcp_server);
 
 /* Create new TCP server instance.
  */


### PR DESCRIPTION
We should aim to make as many structures module-private as possible.