### PR TITLE
Work around bug in opencv3 headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,11 @@ if(NOT WIN32 AND BUILD_TOXAV AND SNDFILE_FOUND AND PORTAUDIO_FOUND AND OPENCV_FO
     ${OPENCV_LIBRARIES}
     ${PORTAUDIO_LIBRARIES}
     ${SNDFILE_LIBRARIES})
+  # Due to https://github.com/opencv/opencv/issues/6585, we need to compile
+  # av_test as C++ for newer OpenCV versions.
+  if(NOT OPENCV_VERSION VERSION_LESS 3)
+    set_source_files_properties(testing/av_test.c PROPERTIES LANGUAGE CXX)
+  endif()
 endif()
 
 if(NOT WIN32)

--- a/other/astyle/format-source
+++ b/other/astyle/format-source
@@ -20,8 +20,8 @@ if ! which "$ASTYLE"; then
   exit 1
 fi
 
-if [ -f ../apidsl/_build/apigen.native ]; then
-  APIDSL=../apidsl/_build/apigen.native
+if [ -f ../apidsl/apigen.native ]; then
+  APIDSL=../apidsl/apigen.native
 else
   APIDSL=apidsl_curl
 fi

--- a/testing/av_test.c
+++ b/testing/av_test.c
@@ -22,6 +22,10 @@
  *   -lopencv_highgui -lopencv_imgproc -lsndfile -pthread -lvpx -lopus -lsodium -lportaudio
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // XXX: Hack because toxav doesn't really expose ring_buffer, but this av test
 // uses it. Not all of these functions are used, but when linking statically,
 // not renaming them will cause multiple definition errors, so we need to rename
@@ -37,11 +41,14 @@
 #define rb_data  test_rb_data
 #include "../toxav/ring_buffer.c"
 
-#include "../toxav/ring_buffer.h"
 #include "../toxav/toxav.h"
 #include "../toxcore/network.h" /* current_time_monotonic() */
 #include "../toxcore/tox.h"
 #include "../toxcore/util.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 /* Playing audio data */
 #include <portaudio.h>
@@ -175,7 +182,9 @@ static void t_toxav_receive_video_frame_cb(ToxAV *av, uint32_t friend_number,
 
     CvMat mat = cvMat(height, width, CV_8UC3, img_data);
 
-    CvSize sz = {.height = height, .width = width};
+    CvSize sz;
+    sz.height = height;
+    sz.width = width;
 
     IplImage *header = cvCreateImageHeader(sz, 1, 3);
     IplImage *img = cvGetImage(&mat, header);
@@ -598,9 +607,9 @@ CHECK_ARG:
 
         /* Start decode thread */
         struct toxav_thread_data data = {
-            .AliceAV = AliceAV,
-            .BobAV = BobAV,
-            .sig = 0
+            AliceAV,
+            BobAV,
+            0,
         };
 
         pthread_t dect;
@@ -723,9 +732,9 @@ CHECK_ARG:
 
         /* Start decode thread */
         struct toxav_thread_data data = {
-            .AliceAV = AliceAV,
-            .BobAV = BobAV,
-            .sig = 0
+            AliceAV,
+            BobAV,
+            0,
         };
 
         pthread_t dect;
@@ -739,7 +748,9 @@ CHECK_ARG:
             exit(1);
         }
 
-//         toxav_video_bit_rate_set(AliceAV, 0, 5000, false, NULL);
+#if 0
+        toxav_video_bit_rate_set(AliceAV, 0, 5000, false, NULL);
+#endif
 
         time_t start_time = time(NULL);
 

--- a/toxav/ring_buffer.c
+++ b/toxav/ring_buffer.c
@@ -47,7 +47,7 @@ bool rb_read(RingBuffer *b, void **p)
 }
 RingBuffer *rb_new(int size)
 {
-    RingBuffer *buf = calloc(sizeof(RingBuffer), 1);
+    RingBuffer *buf = (RingBuffer *)calloc(sizeof(RingBuffer), 1);
 
     if (!buf) {
         return NULL;
@@ -55,7 +55,7 @@ RingBuffer *rb_new(int size)
 
     buf->size = size + 1; /* include empty elem */
 
-    if (!(buf->data = calloc(buf->size, sizeof(void *)))) {
+    if (!(buf->data = (void **)calloc(buf->size, sizeof(void *)))) {
         free(buf);
         return NULL;
     }


### PR DESCRIPTION
OpenCV 3.1 doesn't define cvRound in C, only in C++. Thus, we now need
to compile av_test as C++ code.