### PR TITLE
Minor cleanups: unused vars, unreachable code, static globals.

### DIFF
--- a/auto_tests/TCP_test.c
+++ b/auto_tests/TCP_test.c
@@ -25,7 +25,7 @@
 
 #define NUM_PORTS 3
 
-uint16_t ports[NUM_PORTS] = {1234, 33445, 25643};
+static uint16_t ports[NUM_PORTS] = {1234, 33445, 25643};
 
 START_TEST(test_basic)
 {
@@ -522,7 +522,7 @@ END_TEST
 
 #include "../toxcore/TCP_connection.h"
 
-bool tcp_data_callback_called;
+static bool tcp_data_callback_called;
 static int tcp_data_callback(void *object, int id, const uint8_t *data, uint16_t length, void *userdata)
 {
     if (object != (void *)120397) {
@@ -632,7 +632,7 @@ START_TEST(test_tcp_connection)
 }
 END_TEST
 
-bool tcp_oobdata_callback_called;
+static bool tcp_oobdata_callback_called;
 static int tcp_oobdata_callback(void *object, const uint8_t *public_key, unsigned int id, const uint8_t *data,
                                 uint16_t length, void *userdata)
 {

--- a/auto_tests/encryptsave_test.c
+++ b/auto_tests/encryptsave_test.c
@@ -59,7 +59,6 @@ START_TEST(test_save_friend)
     Tox *tox1 = tox_new(0, 0);
     Tox *tox2 = tox_new(0, 0);
     ck_assert_msg(tox1 || tox2, "Failed to create 2 tox instances");
-    uint32_t to_compare = 974536;
     tox_callback_friend_request(tox2, accept_friend_request);
     uint8_t address[TOX_ADDRESS_SIZE];
     tox_self_get_address(tox2, address);

--- a/auto_tests/tox_test.c
+++ b/auto_tests/tox_test.c
@@ -1384,9 +1384,9 @@ group_test_restart:
 END_TEST
 
 #ifdef TRAVIS_ENV
-uint8_t timeout_mux = 20;
+static const uint8_t timeout_mux = 20;
 #else
-uint8_t timeout_mux = 10;
+static const uint8_t timeout_mux = 10;
 #endif
 
 static Suite *tox_suite(void)

--- a/auto_tests/toxav_basic_test.c
+++ b/auto_tests/toxav_basic_test.c
@@ -169,7 +169,6 @@ START_TEST(test_AV_flows)
     printf("Preparing network...\n");
     long long unsigned int cur_time = time(NULL);
 
-    uint32_t to_compare = 974536;
     uint8_t address[TOX_ADDRESS_SIZE];
 
     tox_callback_friend_request(Alice, t_accept_friend_request_cb);

--- a/auto_tests/toxav_many_test.c
+++ b/auto_tests/toxav_many_test.c
@@ -235,7 +235,6 @@ START_TEST(test_AV_three_calls)
     printf("Preparing network...\n");
     long long unsigned int cur_time = time(NULL);
 
-    uint32_t to_compare = 974536;
     uint8_t address[TOX_ADDRESS_SIZE];
 
     tox_callback_friend_request(Alice, t_accept_friend_request_cb);

--- a/other/bootstrap_daemon/src/log.c
+++ b/other/bootstrap_daemon/src/log.c
@@ -31,7 +31,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-LOG_BACKEND current_backend = -1;
+static LOG_BACKEND current_backend = -1;
 
 bool open_log(LOG_BACKEND backend)
 {

--- a/testing/DHT_test.c
+++ b/testing/DHT_test.c
@@ -52,7 +52,7 @@
 
 #define PORT 33445
 
-uint8_t zeroes_cid[crypto_box_PUBLICKEYBYTES];
+static uint8_t zeroes_cid[crypto_box_PUBLICKEYBYTES];
 
 static void print_client_id(uint8_t *public_key)
 {

--- a/toxav/msi.c
+++ b/toxav/msi.c
@@ -384,7 +384,6 @@ int msg_parse_in(Logger *log, MSIMessage *dest, const uint8_t *data, uint16_t le
             default:
                 LOGGER_ERROR(log, "Invalid id byte");
                 return -1;
-                break;
         }
     }
 
@@ -689,7 +688,6 @@ void handle_init(MSICall *call, const MSIMessage *msg)
             call->error = msi_EInvalidState;
             goto FAILURE;
         }
-        break;
     }
 
     return;
@@ -771,7 +769,6 @@ void handle_pop(MSICall *call, const MSIMessage *msg)
                 LOGGER_ERROR(call->session->messenger->log, "Handling what should be impossible case");
                 abort();
             }
-            break;
 
             case msi_CallActive: {
                 /* Hangup */

--- a/toxcore/Messenger.c
+++ b/toxcore/Messenger.c
@@ -2915,7 +2915,6 @@ static int messenger_load_state_callback(void *outer, const uint8_t *data, uint3
             }
 
             return -2;
-            break;
         }
 
 #ifdef TOX_DEBUG

--- a/toxcore/network.c
+++ b/toxcore/network.c
@@ -460,7 +460,7 @@ void networking_poll(Networking_Core *net, void *userdata)
 #include <sodium.h>
 #endif
 
-uint8_t at_startup_ran = 0;
+static uint8_t at_startup_ran = 0;
 int networking_at_startup(void)
 {
     if (at_startup_ran != 0) {


### PR DESCRIPTION
- All global variables should be static unless they have an explicit
  extern declaration in a header file.
- `to_compare` was not used in encryptsave and toxav tests.
- `break` in switch cases is not required directly after `return`,
  `goto`, or a noreturn function like `abort`.