### PR TITLE
Allow the OSX build to fail on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - env: JOB=toxcore ENV=windows ARCH=x86_64
       services:
         - docker
+  fast_finish: true
+  allow_failures:
+    - os: osx
 
 addons:
   apt:


### PR DESCRIPTION
Given that it fails about 80-90% of the time, it's not worth requiring
it to pass. Instead, we'll need to manually look at the osx build to see
in what way it failed.