### PR TITLE
Replace `void*` with `RingBuffer*` to avoid conversions.

### DIFF
--- a/toxav/video.h
+++ b/toxav/video.h
@@ -47,7 +47,7 @@ typedef struct VCSession_s {
 
     /* decoding */
     vpx_codec_ctx_t decoder[1];
-    void *vbuf_raw; /* Un-decoded data */
+    RingBuffer *vbuf_raw; /* Un-decoded data */
 
     uint64_t linfts; /* Last received frame time stamp */
     uint32_t lcfd; /* Last calculated frame duration for incoming video payload */


### PR DESCRIPTION
`vbuf_raw` is always a `RingBuffer*` so there is no need to pretend it
could ever be anything else (as indicated by it being a pointer to
void).