### PR TITLE
Add version-sync script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@ include(CTest)
 
 # This version is for the entire project. All libraries (core, av, ...) move in
 # versions in a synchronised way.
-set(PROJECT_VERSION "0.0.1")
+set(PROJECT_VERSION_MAJOR "0")
+set(PROJECT_VERSION_MINOR "0")
+set(PROJECT_VERSION_PATCH "1")
+set(PROJECT_VERSION
+  "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -381,13 +385,30 @@ endif()
 
 ################################################################################
 #
+# :: Update versions in various places
+#
+################################################################################
+
+find_program(SH NAMES sh dash bash zsh)
+
+if(SH)
+  execute_process(
+    COMMAND ${SH} ${CMAKE_SOURCE_DIR}/other/version-sync
+      ${CMAKE_SOURCE_DIR}
+      ${PROJECT_VERSION_MAJOR}
+      ${PROJECT_VERSION_MINOR}
+      ${PROJECT_VERSION_PATCH})
+endif()
+
+################################################################################
+#
 # :: Strict ABI
 #
 ################################################################################
 
 function(make_version_script header ns lib)
   execute_process(
-    COMMAND sh -c "egrep '^\\w' ${header} | grep '${ns}_[a-z0-9_]*(' | grep -v '^typedef' | grep -o '${ns}_[a-z0-9_]*(' | egrep -o '\\w+' | sort -u"
+    COMMAND ${SH} -c "egrep '^\\w' ${header} | grep '${ns}_[a-z0-9_]*(' | grep -v '^typedef' | grep -o '${ns}_[a-z0-9_]*(' | egrep -o '\\w+' | sort -u"
     OUTPUT_VARIABLE ${lib}_SYMS
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   string(REPLACE "\n" ";" ${lib}_SYMS ${${lib}_SYMS})
@@ -413,7 +434,7 @@ if(WIN32 OR APPLE)
   set(STRICT_ABI OFF)
 endif()
 
-if(STRICT_ABI)
+if(STRICT_ABI AND SH)
   if(BUILD_TOXAV)
     make_version_script(${CMAKE_SOURCE_DIR}/toxav/toxav.h toxav toxav)
   endif()

--- a/other/version-sync
+++ b/other/version-sync
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+SOURCE_DIR=$1
+MAJOR=$2
+MINOR=$3
+PATCH=$4
+
+VER="$MAJOR.$MINOR.$PATCH"
+
+update() {
+  file="$SOURCE_DIR/$1"
+  expr="$2"
+
+  sed -e "$expr" "$file" > "$file.updated-version"
+  if diff "$file" "$file.updated-version"; then
+    rm "$file.updated-version"
+  else
+    mv "$file.updated-version" "$file"
+  fi
+}
+
+update "configure.ac" 's/AC_INIT(\[tox\], \[.*\])/AC_INIT([tox], ['$VER'])/'
+
+update "other/apidsl/tox.in.h" 's/\(const VERSION_MAJOR *= \).*;/\1'$MAJOR';/'
+update "other/apidsl/tox.in.h" 's/\(const VERSION_MINOR *= \).*;/\1'$MINOR';/'
+update "other/apidsl/tox.in.h" 's/\(const VERSION_PATCH *= \).*;/\1'$PATCH';/'


### PR DESCRIPTION
This will update tox.in.h only. Currently, you will still need to
manually update tox.h. An upcoming PR (#154) will update tox.h as
part of the build.